### PR TITLE
remove libsodium dependency in favor of the native go/crypto ed25519 library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,6 @@ Install required dependencies
 This example assumes Ubuntu 16.04
 
 ```sh
-sudo apt-get install pkg-config libsodium-dev
 go get github.com/hkparker/go-i2p
 go get github.com/Sirupsen/logrus
 go get github.com/stretchr/testify/assert

--- a/lib/common/fuzz/Dockerfile
+++ b/lib/common/fuzz/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install libsodium-dev -y
+    apt-get upgrade -y
 
 RUN go get github.com/dvyukov/go-fuzz/go-fuzz
 RUN go get github.com/dvyukov/go-fuzz/go-fuzz-build

--- a/lib/crypto/ed25519_test.go
+++ b/lib/crypto/ed25519_test.go
@@ -1,9 +1,42 @@
 package crypto
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
 	"testing"
 )
 
 func TestEd25519(t *testing.T) {
+	var pubKey Ed25519PublicKey
 
+	signer := new(Ed25519Signer)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Log("Failed to generate ed25519 test key")
+		t.Fail()
+	}
+	pubKey = []byte(pub)
+	signer.k = []byte(priv)
+
+	message := make([]byte, 123)
+	io.ReadFull(rand.Reader, message)
+
+	sig, err := signer.Sign(message)
+	if err != nil {
+		t.Log("Failed to sign message")
+		t.Fail()
+	}
+
+	verifier, err := pubKey.NewVerifier()
+	if err != nil {
+		t.Logf("Error from verifier: %s", err)
+		t.Fail()
+	}
+
+	err = verifier.Verify(message, sig)
+	if err != nil {
+		t.Log("Failed to verify message")
+		t.Fail()
+	}
 }


### PR DESCRIPTION
This PR removes the libsodium dependency in favor of the native go/crypto ed25519 library