### PR TITLE
Rework MappingValues Sort

### DIFF
--- a/lib/common/data/mapping.go
+++ b/lib/common/data/mapping.go
@@ -72,21 +72,6 @@ func (mapping *Mapping) Data() []byte {
 	return bytes
 }
 
-// HasDuplicateKeys returns true if two keys in a mapping are identical.
-func (mapping *Mapping) HasDuplicateKeys() bool {
-	seen_values := make(map[string]bool)
-	values := mapping.Values()
-	for _, pair := range values {
-		key, _ := pair[0].Data()
-		if _, present := seen_values[key]; present {
-			return true
-		} else {
-			seen_values[key] = true
-		}
-	}
-	return false
-}
-
 // GoMapToMapping converts a Go map of unformatted strings to *Mapping.
 func GoMapToMapping(gomap map[string]string) (mapping *Mapping, err error) {
 	map_vals := MappingValues{}

--- a/lib/common/data/mapping.go
+++ b/lib/common/data/mapping.go
@@ -72,6 +72,21 @@ func (mapping *Mapping) Data() []byte {
 	return bytes
 }
 
+// HasDuplicateKeys returns true if two keys in a mapping are identical.
+func (mapping *Mapping) HasDuplicateKeys() bool {
+	seen_values := make(map[string]bool)
+	values := mapping.Values()
+	for _, pair := range values {
+		key, _ := pair[0].Data()
+		if _, present := seen_values[key]; present {
+			return true
+		} else {
+			seen_values[key] = true
+		}
+	}
+	return false
+}
+
 // GoMapToMapping converts a Go map of unformatted strings to *Mapping.
 func GoMapToMapping(gomap map[string]string) (mapping *Mapping, err error) {
 	map_vals := MappingValues{}

--- a/lib/common/data/mapping_test.go
+++ b/lib/common/data/mapping_test.go
@@ -99,6 +99,22 @@ func TestValuesReturnsValues(t *testing.T) {
 	assert.Equal("b", val, "Values() did not return value in valid data")
 }
 
+func TestHasDuplicateKeysTrueWhenDuplicates(t *testing.T) {
+	assert := assert.New(t)
+
+	dups, _, _ := NewMapping([]byte{0x00, 0x0c, 0x01, 0x61, 0x3d, 0x01, 0x62, 0x3b, 0x01, 0x61, 0x3d, 0x01, 0x62, 0x3b})
+
+	assert.Equal(true, dups.HasDuplicateKeys(), "HasDuplicateKeys() did not report true when duplicate keys present")
+}
+
+func TestHasDuplicateKeysFalseWithoutDuplicates(t *testing.T) {
+	assert := assert.New(t)
+
+	mapping, _, _ := NewMapping([]byte{0x00, 0x06, 0x01, 0x61, 0x3d, 0x01, 0x62, 0x3b})
+
+	assert.Equal(false, mapping.HasDuplicateKeys(), "HasDuplicateKeys() did not report false when no duplicate keys present")
+}
+
 func TestReadMappingHasDuplicateKeys(t *testing.T) {
 	assert := assert.New(t)
 

--- a/lib/common/data/mapping_test.go
+++ b/lib/common/data/mapping_test.go
@@ -99,20 +99,12 @@ func TestValuesReturnsValues(t *testing.T) {
 	assert.Equal("b", val, "Values() did not return value in valid data")
 }
 
-func TestHasDuplicateKeysTrueWhenDuplicates(t *testing.T) {
+func TestReadMappingHasDuplicateKeys(t *testing.T) {
 	assert := assert.New(t)
 
-	dups, _, _ := NewMapping([]byte{0x00, 0x0c, 0x01, 0x61, 0x3d, 0x01, 0x62, 0x3b, 0x01, 0x61, 0x3d, 0x01, 0x62, 0x3b})
+	_, _, errs := NewMapping([]byte{0x00, 0x0c, 0x01, 0x61, 0x3d, 0x01, 0x62, 0x3b, 0x01, 0x61, 0x3d, 0x01, 0x62, 0x3b})
 
-	assert.Equal(true, dups.HasDuplicateKeys(), "HasDuplicateKeys() did not report true when duplicate keys present")
-}
-
-func TestHasDuplicateKeysFalseWithoutDuplicates(t *testing.T) {
-	assert := assert.New(t)
-
-	mapping, _, _ := NewMapping([]byte{0x00, 0x06, 0x01, 0x61, 0x3d, 0x01, 0x62, 0x3b})
-
-	assert.Equal(false, mapping.HasDuplicateKeys(), "HasDuplicateKeys() did not report false when no duplicate keys present")
+	assert.Equal("mapping format violation, duplicate key in mapping", errs[0].Error(), "ReadMapping should fail when duplicate keys are present.")
 }
 
 func TestGoMapToMappingProducesCorrectMapping(t *testing.T) {

--- a/lib/common/data/mapping_test.go
+++ b/lib/common/data/mapping_test.go
@@ -120,7 +120,7 @@ func TestReadMappingHasDuplicateKeys(t *testing.T) {
 
 	_, _, errs := NewMapping([]byte{0x00, 0x0c, 0x01, 0x61, 0x3d, 0x01, 0x62, 0x3b, 0x01, 0x61, 0x3d, 0x01, 0x62, 0x3b})
 
-	assert.Equal("mapping format violation, duplicate key in mapping", errs[0].Error(), "ReadMapping should fail when duplicate keys are present.")
+	assert.Equal("mapping format violation, duplicate key in mapping", errs[0].Error(), "ReadMapping should throw an error when duplicate keys are present.")
 }
 
 func TestGoMapToMappingProducesCorrectMapping(t *testing.T) {

--- a/lib/common/data/mapping_values.go
+++ b/lib/common/data/mapping_values.go
@@ -135,7 +135,7 @@ func ReadMappingValues(remainder []byte) (values *MappingValues, remainder_bytes
 			// Based on other implementations this does not seem to happen often?
 			// Java throws an exception in this case, the base object is a Hashmap so the value is overwritten and an exception is thrown.
 			// i2pd  as far as I can tell just overwrites the original value
-			return
+			// Continue on, we can check if the Mapping contains duplicate keys later.
 		}
 
 		if !beginsWith(remainder, 0x3d) {

--- a/lib/common/data/mapping_values_test.go
+++ b/lib/common/data/mapping_values_test.go
@@ -1,38 +1,46 @@
 package data
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestMappingOrderSortsValuesThenKeys(t *testing.T) {
 	a, _ := ToI2PString("a")
 	b, _ := ToI2PString("b")
+	aa, _ := ToI2PString("aa")
+	ab, _ := ToI2PString("ab")
+	ac, _ := ToI2PString("ac")
 	values := MappingValues{
 		[2]I2PString{b, b},
-		[2]I2PString{b, a},
-		[2]I2PString{a, b},
+		[2]I2PString{ac, a},
+		[2]I2PString{ab, b},
+		[2]I2PString{aa, a},
 		[2]I2PString{a, a},
 	}
 	mappingOrder(values)
 	for i, pair := range values {
 		key, _ := pair[0].Data()
-		value, _ := pair[1].Data()
 		switch i {
 		case 0:
-			if !(key == "a" && value == "a") {
-				t.Fatal("mappingOrder produced incorrect sort output at", i)
+			if !(key == "a") {
+				t.Fatal(fmt.Sprintf("mappingOrder expected key a, got %s at index", key), i)
 			}
 		case 1:
-			if !(key == "a" && value == "b") {
-				t.Fatal("mappingOrder produced incorrect sort output at", i)
+			if !(key == "aa") {
+				t.Fatal(fmt.Sprintf("mappingOrder expected key aa, got %s at index", key), i)
 			}
 		case 2:
-			if !(key == "b" && value == "a") {
-				t.Fatal("mappingOrder produced incorrect sort output at", i)
+			if !(key == "ab") {
+				t.Fatal(fmt.Sprintf("mappingOrder expected key ab, got %s at index", key), i)
 			}
 		case 3:
-			if !(key == "b" && value == "b") {
-				t.Fatal("mappingOrder produced incorrect sort output at", i)
+			if !(key == "ac") {
+				t.Fatal(fmt.Sprintf("mappingOrder expected key ac, got %s at index", key), i)
+			}
+		case 4:
+			if !(key == "b") {
+				t.Fatal(fmt.Sprintf("mappingOrder expected key b, got %s at index", key), i)
 			}
 		}
 	}


### PR DESCRIPTION
Simplifies the MappingValues sort.

The specifications don't mention any sorting on values so that bit was entirely removed in favor of just sorting keys.

There was mention of duplicate values being allowed in Mappings, but the Java router throws an exception when one is encountered, i2pd just overwrites the key if a second is encountered (they also don't sort?). Both use HashMaps as the underlying type. In light of this I added an error return similar to the java implementation in ReadMapping to prevent duplicate keys.
