### PR TITLE
Fix key_certificate tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(EXE):
 	$(GO) build -v -o $(EXE)
 
 test:
-	$(GO) test -v -failfast ./lib/common/data/...
+	$(GO) test -v -failfast ./lib/common/data/... ./lib/common/key_certificate
 
 clean:
 	$(GO) clean -v

--- a/lib/common/key_certificate/key_certificate.go
+++ b/lib/common/key_certificate/key_certificate.go
@@ -36,57 +36,58 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Key Certificate Signing Key Types
+// KEYCERT_MIN_SIZE is the minimum size of a Key Certificate
+const KEYCERT_MIN_SIZE = 7
+
+// Signing Public Key Types
 const (
-	KEYCERT_SIGN_DSA_SHA1 = iota
-	KEYCERT_SIGN_P256
-	KEYCERT_SIGN_P384
-	KEYCERT_SIGN_P521
-	KEYCERT_SIGN_RSA2048
-	KEYCERT_SIGN_RSA3072
-	KEYCERT_SIGN_RSA4096
-	KEYCERT_SIGN_ED25519
-	KEYCERT_SIGN_ED25519PH
+	KEYCERT_SIGN_PUBKEY_DSA_SHA1 = iota
+	KEYCERT_SIGN_PUBKEY_P256
+	KEYCERT_SIGN_PUBKEY_P384
+	KEYCERT_SIGN_PUBKEY_P521
+	KEYCERT_SIGN_PUBKEY_RSA2048
+	KEYCERT_SIGN_PUBKEY_RSA3072
+	KEYCERT_SIGN_PUBKEY_RSA4096
+	KEYCERT_SIGN_PUBKEY_ED25519
+	KEYCERT_SIGN_PUBKEY_ED25519PH
 )
 
-// Key Certificate Public Key Types
+// Crypto Public Key Types
 const (
-	KEYCERT_CRYPTO_ELG = iota
+	KEYCERT_CRYPTO_PUBKEY_ELGAMAL = iota
+	KEYCERT_CRYPTO_PUBKEY_P256
+	KEYCERT_CRYPTO_PUBKEY_P384
+	KEYCERT_CRYPTO_PUBKEY_P521
+	KEYCERT_CRYPTO_PUBKEY_X25519
 )
 
+// Signing Public Key sizes in bytes for Signing Public Key Types
 const (
-	KEYCERT_MIN_SIZE = 7
+	KEYCERT_SIGN_PUBKEY_DSA_SHA1_SIZE  = 128
+	KEYCERT_SIGN_PUBKEY_P256_SIZE      = 64
+	KEYCERT_SIGN_PUBKEY_P384_SIZE      = 96
+	KEYCERT_SIGN_PUBKEY_P521_SIZE      = 132
+	KEYCERT_SIGN_PUBKEY_RSA2048_SIZE   = 256
+	KEYCERT_SIGN_PUBKEY_RSA3072_SIZE   = 384
+	KEYCERT_SIGN_PUBKEY_RSA4096_SIZE   = 512
+	KEYCERT_SIGN_PUBKEY_ED25519_SIZE   = 32
+	KEYCERT_SIGN_PUBKEY_ED25519PH_SIZE = 32
 )
 
-// SigningPublicKey sizes for Signing Key Types
+// Crypto Public Key sizes in bytes for Crypto Public Key Types
 const (
-	KEYCERT_SIGN_DSA_SHA1_SIZE  = 128
-	KEYCERT_SIGN_P256_SIZE      = 64
-	KEYCERT_SIGN_P384_SIZE      = 96
-	KEYCERT_SIGN_P521_SIZE      = 132
-	KEYCERT_SIGN_RSA2048_SIZE   = 256
-	KEYCERT_SIGN_RSA3072_SIZE   = 384
-	KEYCERT_SIGN_RSA4096_SIZE   = 512
-	KEYCERT_SIGN_ED25519_SIZE   = 32
-	KEYCERT_SIGN_ED25519PH_SIZE = 32
+	KEYCERT_CRYPTO_PUBKEY_ELGAMAL_SIZE = 256
+	KEYCERT_CRYPTO_PUBKEY_P256_SIZE    = 64
+	KEYCERT_CRYPTO_PUBKEY_P384_SIZE    = 96
+	KEYCERT_CRYPTO_PUBKEY_P521_SIZE    = 132
+	KEYCERT_CRYPTO_PUBKEY_X25519_SIZE  = 32
 )
 
-// PublicKey sizes for Public Key Types
-const (
-	KEYCERT_CRYPTO_ELG_SIZE = 256
-)
-
-// Sizes of structures in KeyCertificates
-const (
-	KEYCERT_PUBKEY_SIZE = 256
-	KEYCERT_SPK_SIZE    = 128
-)
-
-//type KeyCertificate []byte
+// type KeyCertificate []byte
 type KeyCertificate struct {
 	*Certificate
-	spkType Integer
-	cpkType Integer
+	signingPubKeyType Integer
+	certPubKeyType    Integer
 }
 
 // Data returns the raw []byte contained in the Certificate.
@@ -96,37 +97,46 @@ func (key_certificate KeyCertificate) Data() ([]byte, error) {
 
 // SigningPublicKeyType returns the SigningPublicKey type as a Go integer.
 func (key_certificate KeyCertificate) SigningPublicKeyType() (signing_pubkey_type int) {
-	return key_certificate.spkType.Int()
+	return key_certificate.signingPubKeyType.Int()
 }
 
 // PublicKeyType returns the PublicKey type as a Go integer.
 func (key_certificate KeyCertificate) PublicKeyType() (pubkey_type int) {
-	return key_certificate.cpkType.Int()
+	return key_certificate.certPubKeyType.Int()
 }
 
 // ConstructPublicKey returns a PublicKey constructed using any excess data that may be stored in the KeyCertififcate.
 // Returns enr errors encountered while parsing.
 func (key_certificate KeyCertificate) ConstructPublicKey(data []byte) (public_key crypto.PublicKey, err error) {
-	key_type := key_certificate.PublicKeyType()
+	keyType := key_certificate.PublicKeyType()
 	if err != nil {
 		return
 	}
 	data_len := len(data)
-	if data_len < KEYCERT_PUBKEY_SIZE {
+	specifiedPubKeyLength := key_certificate.CryptoPublicKeySize()
+	if data_len < specifiedPubKeyLength {
 		log.WithFields(log.Fields{
-			"at":           "(KeyCertificate) ConstructPublicKey",
-			"data_len":     data_len,
-			"required_len": KEYCERT_PUBKEY_SIZE,
-			"reason":       "not enough data",
+			"at":               "(KeyCertificate) ConstructPublicKey",
+			"data_len":         data_len,
+			"specified_length": specifiedPubKeyLength,
+			"reason":           "not enough data",
 		}).Error("error constructing public key")
 		err = errors.New("error constructing public key: not enough data")
 		return
 	}
-	switch key_type {
-	case KEYCERT_CRYPTO_ELG:
+	switch keyType {
+	case KEYCERT_CRYPTO_PUBKEY_ELGAMAL:
 		var elg_key crypto.ElgPublicKey
-		copy(elg_key[:], data[KEYCERT_PUBKEY_SIZE-KEYCERT_CRYPTO_ELG_SIZE:KEYCERT_PUBKEY_SIZE])
+		copy(elg_key[:], data[:specifiedPubKeyLength])
 		public_key = elg_key
+	case KEYCERT_CRYPTO_PUBKEY_P256:
+		panic("KEYCERT_CRYPTO_PUBKEY_P256 Not implemented")
+	case KEYCERT_CRYPTO_PUBKEY_P384:
+		panic("KEYCERT_CRYPTO_PUBKEY_P384 Not implemented")
+	case KEYCERT_CRYPTO_PUBKEY_P521:
+		panic("KEYCERT_CRYPTO_PUBKEY_P521 Not implemented")
+	case KEYCERT_CRYPTO_PUBKEY_X25519:
+		panic("KEYCERT_CRYPTO_PUBKEY_X25519 Not implemented")
 	}
 	return
 }
@@ -138,65 +148,85 @@ func (key_certificate KeyCertificate) ConstructSigningPublicKey(data []byte) (si
 	if err != nil {
 		return
 	}
+	signingPublicKeySize := key_certificate.SigningPublicKeySize()
 	data_len := len(data)
-	if data_len < KEYCERT_SPK_SIZE {
+	if data_len < signingPublicKeySize {
 		log.WithFields(log.Fields{
 			"at":           "(KeyCertificate) ConstructSigningPublicKey",
 			"data_len":     data_len,
-			"required_len": KEYCERT_SPK_SIZE,
+			"required_len": signingPublicKeySize,
 			"reason":       "not enough data",
 		}).Error("error constructing signing public key")
 		err = errors.New("error constructing signing public key: not enough data")
 		return
 	}
 	switch signing_key_type {
-	case KEYCERT_SIGN_DSA_SHA1:
+	case KEYCERT_SIGN_PUBKEY_DSA_SHA1:
 		var dsa_key crypto.DSAPublicKey
-		copy(dsa_key[:], data[KEYCERT_SPK_SIZE-KEYCERT_SIGN_DSA_SHA1_SIZE:KEYCERT_SPK_SIZE])
+		copy(dsa_key[:], data[:signingPublicKeySize])
 		signing_public_key = dsa_key
-	case KEYCERT_SIGN_P256:
+	case KEYCERT_SIGN_PUBKEY_P256:
 		var ec_key crypto.ECP256PublicKey
-		copy(ec_key[:], data[KEYCERT_SPK_SIZE-KEYCERT_SIGN_P256_SIZE:KEYCERT_SPK_SIZE])
+		copy(ec_key[:], data[:signingPublicKeySize])
 		signing_public_key = ec_key
-	case KEYCERT_SIGN_P384:
+	case KEYCERT_SIGN_PUBKEY_P384:
 		var ec_key crypto.ECP384PublicKey
-		copy(ec_key[:], data[KEYCERT_SPK_SIZE-KEYCERT_SIGN_P384_SIZE:KEYCERT_SPK_SIZE])
+		copy(ec_key[:], data[:signingPublicKeySize])
 		signing_public_key = ec_key
-	case KEYCERT_SIGN_P521:
+	case KEYCERT_SIGN_PUBKEY_P521:
+		// Build the entire pubkey using the bytes available in the PublicKey + 4 excess bytes from the certificate
+		var fullCertData []byte
+		fullCertData = append(fullCertData, data[:signingPublicKeySize]...)
+		fullCertData = append(fullCertData, key_certificate.Certificate.RawBytes()[:4]...)
 		var ec_key crypto.ECP521PublicKey
-		extra := KEYCERT_SIGN_P521_SIZE - KEYCERT_SPK_SIZE
-		copy(ec_key[:], data)
-		copy(ec_key[KEYCERT_SPK_SIZE:], key_certificate.Certificate.RawBytes()[4:4+extra])
+		copy(ec_key[:], fullCertData)
 		signing_public_key = ec_key
-	case KEYCERT_SIGN_RSA2048:
+	case KEYCERT_SIGN_PUBKEY_RSA2048:
 		//var rsa_key crypto.RSA2048PublicKey
 		//extra := KEYCERT_SIGN_RSA2048_SIZE - 128
 		//copy(rsa_key[:], data)
 		//copy(rsa_key[128:], key_certificate[4:4+extra])
 		//signing_public_key = rsa_key
-	case KEYCERT_SIGN_RSA3072:
-	case KEYCERT_SIGN_RSA4096:
-	case KEYCERT_SIGN_ED25519:
-	case KEYCERT_SIGN_ED25519PH:
+	case KEYCERT_SIGN_PUBKEY_RSA3072:
+		panic("KEYCERT_SIGN_PUBKEY_RSA3072 not implemented")
+	case KEYCERT_SIGN_PUBKEY_RSA4096:
+		panic("KEYCERT_SIGN_PUBKEY_RSA4096 not implemented")
+	case KEYCERT_SIGN_PUBKEY_ED25519:
+		panic("KEYCERT_SIGN_PUBKEY_ED25519 not implemented")
+	case KEYCERT_SIGN_PUBKEY_ED25519PH:
+		panic("KEYCERT_SIGN_PUBKEY_ED25519PH not implemented")
 	}
 	return
 }
 
-// SignatureSize return the size of a Signature corresponding to the Key Certificate's SigningPublicKey type.
-func (key_certificate KeyCertificate) SignatureSize() (size int) {
+// SigningPublicKeySize return the size of a Signing Public Key in bytes corresponding to the Key Certificate's SigningPublicKey type.
+func (key_certificate KeyCertificate) SigningPublicKeySize() (size int) {
 	sizes := map[int]int{
-		KEYCERT_SIGN_DSA_SHA1:  40,
-		KEYCERT_SIGN_P256:      64,
-		KEYCERT_SIGN_P384:      96,
-		KEYCERT_SIGN_P521:      132,
-		KEYCERT_SIGN_RSA2048:   256,
-		KEYCERT_SIGN_RSA3072:   384,
-		KEYCERT_SIGN_RSA4096:   512,
-		KEYCERT_SIGN_ED25519:   64,
-		KEYCERT_SIGN_ED25519PH: 64,
+		KEYCERT_SIGN_PUBKEY_DSA_SHA1:  KEYCERT_SIGN_PUBKEY_DSA_SHA1_SIZE,
+		KEYCERT_SIGN_PUBKEY_P256:      KEYCERT_SIGN_PUBKEY_P256_SIZE,
+		KEYCERT_SIGN_PUBKEY_P384:      KEYCERT_SIGN_PUBKEY_P384_SIZE,
+		KEYCERT_SIGN_PUBKEY_P521:      KEYCERT_SIGN_PUBKEY_P521_SIZE,
+		KEYCERT_SIGN_PUBKEY_RSA2048:   KEYCERT_SIGN_PUBKEY_RSA2048_SIZE,
+		KEYCERT_SIGN_PUBKEY_RSA3072:   KEYCERT_SIGN_PUBKEY_RSA3072_SIZE,
+		KEYCERT_SIGN_PUBKEY_RSA4096:   KEYCERT_SIGN_PUBKEY_RSA4096_SIZE,
+		KEYCERT_SIGN_PUBKEY_ED25519:   KEYCERT_SIGN_PUBKEY_ED25519_SIZE,
+		KEYCERT_SIGN_PUBKEY_ED25519PH: KEYCERT_SIGN_PUBKEY_ED25519PH_SIZE,
 	}
 	key_type := key_certificate.SigningPublicKeyType()
 	return sizes[int(key_type)]
+}
+
+// PublicKeySize returns the size of the Public Key in bytes corresponding to the Key Certificate's CyrptoPublicKey type.
+func (key_certificate KeyCertificate) CryptoPublicKeySize() int {
+	sizes := map[int]int{
+		KEYCERT_CRYPTO_PUBKEY_ELGAMAL: KEYCERT_CRYPTO_PUBKEY_ELGAMAL_SIZE,
+		KEYCERT_CRYPTO_PUBKEY_P256:    KEYCERT_CRYPTO_PUBKEY_P256_SIZE,
+		KEYCERT_CRYPTO_PUBKEY_P384:    KEYCERT_CRYPTO_PUBKEY_P384_SIZE,
+		KEYCERT_CRYPTO_PUBKEY_P521:    KEYCERT_CRYPTO_PUBKEY_P521_SIZE,
+		KEYCERT_CRYPTO_PUBKEY_X25519:  KEYCERT_CRYPTO_PUBKEY_X25519_SIZE,
+	}
+	keyType := key_certificate.PublicKeyType()
+	return sizes[keyType]
 }
 
 // NewKeyCertificate creates a new *KeyCertificate from []byte using ReadCertificate.
@@ -214,30 +244,34 @@ func NewKeyCertificate(bytes []byte) (key_certificate *KeyCertificate, remainder
 	switch len(bytes) {
 	case 4:
 		key_certificate = &KeyCertificate{
-			Certificate: certificate,
-			spkType:     Integer(bytes[4:]),
-			cpkType:     Integer([]byte{0}),
+			Certificate:       certificate,
+			signingPubKeyType: Integer(bytes[4:]),
+			certPubKeyType:    Integer([]byte{0}),
 		}
+		remainder = []byte{}
 	case 5:
 		key_certificate = &KeyCertificate{
-			Certificate: certificate,
-			spkType:     Integer(bytes[4:5]),
-			cpkType:     Integer([]byte{0}),
+			Certificate:       certificate,
+			signingPubKeyType: Integer(bytes[4:5]),
+			certPubKeyType:    Integer([]byte{0}),
 		}
+		remainder = []byte{}
 	case 6:
 		key_certificate = &KeyCertificate{
-			Certificate: certificate,
-			spkType:     Integer(bytes[4:5]),
-			cpkType:     Integer(bytes[6:]),
+			Certificate:       certificate,
+			signingPubKeyType: Integer(bytes[4:5]),
+			certPubKeyType:    Integer(bytes[6:]),
 		}
+		remainder = []byte{}
 	default:
 		key_certificate = &KeyCertificate{
-			Certificate: certificate,
-			spkType:     Integer(bytes[4:5]),
-			cpkType:     Integer(bytes[6:7]),
+			Certificate:       certificate,
+			signingPubKeyType: Integer(bytes[4:5]),
+			certPubKeyType:    Integer(bytes[6:7]),
 		}
+		remainder = bytes[7:]
 	}
-	remainder = bytes[7:]
+
 	//key_certificate.PublicKey = NewPublicKey(bytes)
 	return
 }

--- a/lib/common/key_certificate/key_certificate_test.go
+++ b/lib/common/key_certificate/key_certificate_test.go
@@ -13,7 +13,7 @@ func TestSingingPublicKeyTypeReturnsCorrectInteger(t *testing.T) {
 	pk_type := key_cert.SigningPublicKeyType()
 
 	assert.Nil(err, "SigningPublicKeyType() returned error with valid data")
-	assert.Equal(pk_type, KEYCERT_SIGN_P521, "SigningPublicKeyType() did not return correct typec")
+	assert.Equal(pk_type, KEYCERT_SIGN_PUBKEY_P521, "SigningPublicKeyType() did not return correct typec")
 }
 
 func TestSingingPublicKeyTypeReportsWhenDataTooSmall(t *testing.T) {
@@ -36,7 +36,7 @@ func TestPublicKeyTypeReturnsCorrectInteger(t *testing.T) {
 	pk_type := key_cert.PublicKeyType()
 
 	assert.Nil(err, "PublicKey() returned error with valid data")
-	assert.Equal(pk_type, KEYCERT_SIGN_P521, "PublicKeyType() did not return correct typec")
+	assert.Equal(pk_type, KEYCERT_SIGN_PUBKEY_P521, "PublicKeyType() did not return correct typec")
 }
 
 func TestPublicKeyTypeReportsWhenDataTooSmall(t *testing.T) {
@@ -94,7 +94,7 @@ func TestConstructSigningPublicKeyWithDSASHA1(t *testing.T) {
 	spk, err := key_cert.ConstructSigningPublicKey(data)
 
 	assert.Nil(err, "ConstructSigningPublicKey() with DSA SHA1 returned error with valid data")
-	assert.Equal(spk.Len(), KEYCERT_SIGN_DSA_SHA1_SIZE, "ConstructSigningPublicKey() with DSA SHA1 returned incorrect SigningPublicKey length")
+	assert.Equal(spk.Len(), KEYCERT_SIGN_PUBKEY_DSA_SHA1_SIZE, "ConstructSigningPublicKey() with DSA SHA1 returned incorrect SigningPublicKey length")
 }
 
 func TestConstructSigningPublicKeyWithP256(t *testing.T) {
@@ -105,7 +105,7 @@ func TestConstructSigningPublicKeyWithP256(t *testing.T) {
 	spk, err := key_cert.ConstructSigningPublicKey(data)
 
 	assert.Nil(err, "ConstructSigningPublicKey() with P256 returned err on valid data")
-	assert.Equal(spk.Len(), KEYCERT_SIGN_P256_SIZE, "ConstructSigningPublicKey() with P256 returned incorrect SigningPublicKey length")
+	assert.Equal(spk.Len(), KEYCERT_SIGN_PUBKEY_P256_SIZE, "ConstructSigningPublicKey() with P256 returned incorrect SigningPublicKey length")
 }
 
 func TestConstructSigningPublicKeyWithP384(t *testing.T) {
@@ -116,16 +116,16 @@ func TestConstructSigningPublicKeyWithP384(t *testing.T) {
 	spk, err := key_cert.ConstructSigningPublicKey(data)
 
 	assert.Nil(err, "ConstructSigningPublicKey() with P384 returned err on valid data")
-	assert.Equal(spk.Len(), KEYCERT_SIGN_P384_SIZE, "ConstructSigningPublicKey() with P384 returned incorrect SigningPublicKey length")
+	assert.Equal(spk.Len(), KEYCERT_SIGN_PUBKEY_P384_SIZE, "ConstructSigningPublicKey() with P384 returned incorrect SigningPublicKey length")
 }
 
 func TestConstructSigningPublicKeyWithP521(t *testing.T) {
 	assert := assert.New(t)
 
 	key_cert, _, err := NewKeyCertificate([]byte{0x05, 0x00, 0x08, 0x00, 0x03, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00})
-	data := make([]byte, 128)
+	data := make([]byte, 132)
 	spk, err := key_cert.ConstructSigningPublicKey(data)
 
 	assert.Nil(err, "ConstructSigningPublicKey() with P521 returned err on valid data")
-	assert.Equal(spk.Len(), KEYCERT_SIGN_P521_SIZE, "ConstructSigningPublicKey() with P521 returned incorrect SigningPublicKey length")
+	assert.Equal(spk.Len(), KEYCERT_SIGN_PUBKEY_P521_SIZE, "ConstructSigningPublicKey() with P521 returned incorrect SigningPublicKey length")
 }


### PR DESCRIPTION
Fixes key_certificate tests
Some readability changes, i found some of the previous variables confusing, the distinction between crypto public key and signing public key was not always clear. 