### PR TITLE
Makefiles for tests + hotfix for logging naming convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,30 @@ callvis:
 
 godoc:
 	find lib -type d -exec bash -c "ls {}/*.go && godocdown -o ./{}/doc.md ./{}" \;
+
+# Include test definitions
+-include doc/tests/*.mk
+
+# Define the all-tests target that runs every test suite
+test-all: test-string-all \
+         test-mapping-all \
+         test-crypto-aes-all \
+         test-crypto-dsa-all \
+         test-crypto-ed25519-all \
+         test-crypto-elg-all \
+         test-crypto-hmac-all \
+         test-i2np-header-all \
+         test-i2np-build-request-all \
+         test-key-cert-all \
+         test-keys-cert-all \
+         test-lease-set-all \
+         test-noise-transport-all \
+         test-router-address-all \
+         test-router-info-all \
+         test-su3-all \
+         test-tunnel-all
+
+#-include $(shell find doc/tests -type f -name '*.mk') #search for .mk files recursively
+
+#test-base64-encode-decode-not-mangled:
+	#go test -v ./lib/common/base64 -run TestEncodeDecodeNotMangled

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ export DEBUG_I2P=warn
 export DEBUG_I2P=error
 ```
 
-In case I2P_DEBUG is set to an unrecognized variable, it will fall back to "debug".
+If I2P_DEBUG is set to an unrecognized variable, it will fall back to "debug".
 
 ## Contributing
 

--- a/doc/tests/aes.mk
+++ b/doc/tests/aes.mk
@@ -1,0 +1,17 @@
+test-crypto-aes-all: test-crypto-aes-core test-crypto-aes-validation test-crypto-aes-padding
+
+test-crypto-aes-core:
+	go test -v ./lib/crypto -run TestAESEncryptDecrypt
+
+test-crypto-aes-validation:
+	go test -v ./lib/crypto -run TestAESEncryptInvalidKey
+	go test -v ./lib/crypto -run TestAESDecryptInvalidInput
+
+test-crypto-aes-padding:
+	go test -v ./lib/crypto -run TestPKCS7PadUnpad
+	go test -v ./lib/crypto -run TestPKCS7UnpadInvalidInput
+
+.PHONY: test-crypto-aes-all \
+        test-crypto-aes-core \
+        test-crypto-aes-validation \
+        test-crypto-aes-padding

--- a/doc/tests/base32.mk
+++ b/doc/tests/base32.mk
@@ -1,0 +1,4 @@
+test-base32-encode-decode-not-mangled:
+	go test -v ./lib/common/base32 -run TestEncodeDecodeNotMangled
+
+.PHONY: test-base32-encode-decode-not-mangled

--- a/doc/tests/base64.mk
+++ b/doc/tests/base64.mk
@@ -1,0 +1,4 @@
+test-base64-encode-decode-not-mangled:
+	go test -v ./lib/common/base64 -run TestEncodeDecodeNotMangled
+
+.PHONY: test-base64-encode-decode-not-mangled

--- a/doc/tests/build_request_record.mk
+++ b/doc/tests/build_request_record.mk
@@ -1,0 +1,24 @@
+test-build-request-all: test-build-request-receive test-build-request-ident test-build-request-components
+
+test-build-request-receive:
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordReceiveTunnel
+
+test-build-request-ident:
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordOurIdent
+
+test-build-request-components:
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordNextTunnel
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordNextIdent
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordLayerKey
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordIVKey
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordReplyKey
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordReplyIV
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordFlag
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordRequestTime
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordSendMessageID
+	go test -v ./lib/i2np -run TestReadBuildRequestRecordPadding
+
+.PHONY: test-build-request-all \
+        test-build-request-receive \
+        test-build-request-ident \
+        test-build-request-components

--- a/doc/tests/certificate.mk
+++ b/doc/tests/certificate.mk
@@ -1,0 +1,61 @@
+
+test-cert-all: test-cert-type test-cert-length test-cert-data test-cert-read test-cert-length-correct test-cert-length-too-short test-cert-length-data-short test-cert-data-correct test-cert-data-too-long test-cert-data-too-short test-cert-read-correct test-cert-read-short test-cert-read-remainder test-cert-read-invalid
+
+test-cert-type:
+	go test -v ./lib/common/certificate -run TestCertificateTypeIsFirstByte
+
+test-cert-length:
+	go test -v ./lib/common/certificate -run TestCertificateLength
+
+test-cert-data:
+	go test -v ./lib/common/certificate -run TestCertificateData
+
+test-cert-read:
+	go test -v ./lib/common/certificate -run TestReadCertificate
+
+test-cert-length-correct:
+	go test -v ./lib/common/certificate -run TestCertificateLengthCorrect
+
+test-cert-length-too-short:
+	go test -v ./lib/common/certificate -run TestCertificateLengthErrWhenTooShort
+
+test-cert-length-data-short:
+	go test -v ./lib/common/certificate -run TestCertificateLengthErrWhenDataTooShort
+
+test-cert-data-correct:
+	go test -v ./lib/common/certificate -run TestCertificateDataWhenCorrectSize
+
+test-cert-data-too-long:
+	go test -v ./lib/common/certificate -run TestCertificateDataWhenTooLong
+
+test-cert-data-too-short:
+	go test -v ./lib/common/certificate -run TestCertificateDataWhenTooShort
+
+test-cert-read-correct:
+	go test -v ./lib/common/certificate -run TestReadCertificateWithCorrectData
+
+test-cert-read-short:
+	go test -v ./lib/common/certificate -run TestReadCertificateWithDataTooShort
+
+test-cert-read-remainder:
+	go test -v ./lib/common/certificate -run TestReadCertificateWithRemainder
+
+test-cert-read-invalid:
+	go test -v ./lib/common/certificate -run TestReadCertificateWithInvalidLength
+
+# Declare all targets as PHONY
+.PHONY: test-cert-all \
+        test-cert-type \
+        test-cert-length \
+        test-cert-data \
+        test-cert-read \
+        test-cert-length-correct \
+        test-cert-length-too-short \
+        test-cert-length-data-short \
+        test-cert-data-correct \
+        test-cert-data-too-long \
+        test-cert-data-too-short \
+        test-cert-read-correct \
+        test-cert-read-short \
+        test-cert-read-remainder \
+        test-cert-read-invalid

--- a/doc/tests/date.mk
+++ b/doc/tests/date.mk
@@ -1,0 +1,2 @@
+test-date-time-from-milliseconds:
+	go test -v ./lib/common/data -run TestTimeFromMilliseconds

--- a/doc/tests/dsa.mk
+++ b/doc/tests/dsa.mk
@@ -1,0 +1,20 @@
+test-crypto-dsa-all: test-crypto-dsa test-crypto-dsa-benchmarks
+
+test-crypto-dsa:
+	go test -v ./lib/crypto -run TestDSA
+
+test-crypto-dsa-benchmarks:
+	go test -v ./lib/crypto -bench=DSA -run=^$
+
+# Individual benchmarks
+test-crypto-dsa-bench-generate:
+	go test -v ./lib/crypto -bench=DSAGenerate -run=^$
+
+test-crypto-dsa-bench-sign-verify:
+	go test -v ./lib/crypto -bench=DSASignVerify -run=^$
+
+.PHONY: test-crypto-dsa-all \
+        test-crypto-dsa \
+        test-crypto-dsa-benchmarks \
+        test-crypto-dsa-bench-generate \
+        test-crypto-dsa-bench-sign-verify

--- a/doc/tests/ed25519.mk
+++ b/doc/tests/ed25519.mk
@@ -1,0 +1,7 @@
+test-crypto-ed25519-all: test-crypto-ed25519
+
+test-crypto-ed25519:
+	go test -v ./lib/crypto -run TestEd25519
+
+.PHONY: test-crypto-ed25519-all \
+        test-crypto-ed25519

--- a/doc/tests/elg.mk
+++ b/doc/tests/elg.mk
@@ -1,0 +1,24 @@
+test-crypto-elg-all: test-crypto-elg test-crypto-elg-benchmarks
+
+test-crypto-elg:
+	go test -v ./lib/crypto -run TestElg
+
+test-crypto-elg-benchmarks:
+	go test -v ./lib/crypto -bench=Elg -run=^$
+
+# Individual benchmarks
+test-crypto-elg-bench-generate:
+	go test -v ./lib/crypto -bench=ElgGenerate -run=^$
+
+test-crypto-elg-bench-encrypt:
+	go test -v ./lib/crypto -bench=ElgEncrypt -run=^$
+
+test-crypto-elg-bench-decrypt:
+	go test -v ./lib/crypto -bench=ElgDecrypt -run=^$
+
+.PHONY: test-crypto-elg-all \
+        test-crypto-elg \
+        test-crypto-elg-benchmarks \
+        test-crypto-elg-bench-generate \
+        test-crypto-elg-bench-encrypt \
+        test-crypto-elg-bench-decrypt

--- a/doc/tests/header.mk
+++ b/doc/tests/header.mk
@@ -1,0 +1,30 @@
+
+test-i2np-header-all: test-i2np-type test-i2np-message test-i2np-expiration test-i2np-ntcp-components test-i2np-data test-i2np-regression
+
+test-i2np-type:
+	go test -v ./lib/i2np -run TestReadI2NPTypeWith
+
+test-i2np-message:
+	go test -v ./lib/i2np -run TestReadI2NPNTCPMessageID
+
+test-i2np-expiration:
+	go test -v ./lib/i2np -run TestReadI2NPNTCPMessageExpiration
+	go test -v ./lib/i2np -run TestReadI2NPSSUMessageExpiration
+
+test-i2np-ntcp-components:
+	go test -v ./lib/i2np -run TestReadI2NPNTCPMessageSize
+	go test -v ./lib/i2np -run TestReadI2NPNTCPMessageChecksum
+
+test-i2np-data:
+	go test -v ./lib/i2np -run TestReadI2NPNTCPData
+
+test-i2np-regression:
+	go test -v ./lib/i2np -run TestCrasherRegression123781
+
+.PHONY: test-i2np-header-all \
+        test-i2np-type \
+        test-i2np-message \
+        test-i2np-expiration \
+        test-i2np-ntcp-components \
+        test-i2np-data \
+        test-i2np-regression

--- a/doc/tests/hmac.mk
+++ b/doc/tests/hmac.mk
@@ -1,0 +1,7 @@
+test-crypto-hmac-all: test-crypto-hmac
+
+test-crypto-hmac:
+	go test -v ./lib/crypto -run Test_I2PHMAC
+
+.PHONY: test-crypto-hmac-all \
+        test-crypto-hmac

--- a/doc/tests/integer.mk
+++ b/doc/tests/integer.mk
@@ -1,0 +1,15 @@
+test-integer-all: test-integer-big-endian test-integer-one-byte test-integer-zero
+
+test-integer-big-endian:
+	go test -v ./lib/common/integer -run TestIntegerBigEndian
+
+test-integer-one-byte:
+	go test -v ./lib/common/integer -run TestWorksWithOneByte
+
+test-integer-zero:
+	go test -v ./lib/common/integer -run TestIsZeroWithNoData
+
+.PHONY: test-integer-all \
+        test-integer-big-endian \
+        test-integer-one-byte \
+        test-integer-zero

--- a/doc/tests/key_certificate.mk
+++ b/doc/tests/key_certificate.mk
@@ -1,0 +1,23 @@
+test-key-cert-all: test-key-cert-signing test-key-cert-public test-key-cert-construct
+
+test-key-cert-signing:
+	go test -v ./lib/common/key_certificate -run TestSingingPublicKeyTypeReturnsCorrectInteger
+	go test -v ./lib/common/key_certificate -run TestSingingPublicKeyTypeReportsWhenDataTooSmall
+	go test -v ./lib/common/key_certificate -run TestConstructSigningPublicKeyReportsWhenDataTooSmall
+	go test -v ./lib/common/key_certificate -run TestConstructSigningPublicKeyWithDSASHA1
+	go test -v ./lib/common/key_certificate -run TestConstructSigningPublicKeyWithP256
+	go test -v ./lib/common/key_certificate -run TestConstructSigningPublicKeyWithP384
+	go test -v ./lib/common/key_certificate -run TestConstructSigningPublicKeyWithP521
+
+test-key-cert-public:
+	go test -v ./lib/common/key_certificate -run TestPublicKeyTypeReturnsCorrectInteger
+	go test -v ./lib/common/key_certificate -run TestPublicKeyTypeReportsWhenDataTooSmall
+
+test-key-cert-construct:
+	go test -v ./lib/common/key_certificate -run TestConstructPublicKeyReportsWhenDataTooSmall
+	go test -v ./lib/common/key_certificate -run TestConstructPublicKeyReturnsCorrectDataWithElg
+
+.PHONY: test-key-cert-all \
+        test-key-cert-signing \
+        test-key-cert-public \
+        test-key-cert-construct

--- a/doc/tests/keys_and_cert.mk
+++ b/doc/tests/keys_and_cert.mk
@@ -1,0 +1,30 @@
+test-keys-cert-all: test-keys-cert-certificate test-keys-cert-public test-keys-cert-signing test-keys-cert-creation
+
+test-keys-cert-certificate:
+	go test -v ./lib/common/keys_and_cert -run TestCertificateWithValidData
+
+test-keys-cert-public:
+	go test -v ./lib/common/keys_and_cert -run TestPublicKeyWithBadData
+	go test -v ./lib/common/keys_and_cert -run TestPublicKeyWithBadCertificate
+	go test -v ./lib/common/keys_and_cert -run TestPublicKeyWithNullCertificate
+	go test -v ./lib/common/keys_and_cert -run TestPublicKeyWithKeyCertificate
+
+test-keys-cert-signing:
+	go test -v ./lib/common/keys_and_cert -run TestSigningPublicKeyWithBadData
+	go test -v ./lib/common/keys_and_cert -run TestSigningPublicKeyWithBadCertificate
+	go test -v ./lib/common/keys_and_cert -run TestSigningPublicKeyWithNullCertificate
+	go test -v ./lib/common/keys_and_cert -run TestSigningPublicKeyWithKeyCertificate
+
+test-keys-cert-creation:
+	go test -v ./lib/common/keys_and_cert -run TestNewKeysAndCertWithMissingData
+	go test -v ./lib/common/keys_and_cert -run TestNewKeysAndCertWithMissingCertData
+	go test -v ./lib/common/keys_and_cert -run TestNewKeysAndCertWithValidDataWithCertificate
+	go test -v ./lib/common/keys_and_cert -run TestNewKeysAndCertWithValidDataWithoutCertificate
+	go test -v ./lib/common/keys_and_cert -run TestNewKeysAndCertWithValidDataWithCertificateAndRemainder
+	go test -v ./lib/common/keys_and_cert -run TestNewKeysAndCertWithValidDataWithoutCertificateAndRemainder
+
+.PHONY: test-keys-cert-all \
+        test-keys-cert-certificate \
+        test-keys-cert-public \
+        test-keys-cert-signing \
+        test-keys-cert-creation

--- a/doc/tests/lease_set.mk
+++ b/doc/tests/lease_set.mk
@@ -1,0 +1,22 @@
+test-lease-set-all: test-lease-set-basic test-lease-set-leases test-lease-set-expiration
+
+test-lease-set-basic:
+	go test -v ./lib/common/lease_set -run TestDestinationIsCorrect
+	go test -v ./lib/common/lease_set -run TestPublicKeyIsCorrect
+	go test -v ./lib/common/lease_set -run TestSigningKeyIsCorrect
+	go test -v ./lib/common/lease_set -run TestSignatureIsCorrect
+
+test-lease-set-leases:
+	go test -v ./lib/common/lease_set -run TestLeaseCountCorrect
+	go test -v ./lib/common/lease_set -run TestLeaseCountCorrectWithMultiple
+	go test -v ./lib/common/lease_set -run TestLeaseCountErrorWithTooMany
+	go test -v ./lib/common/lease_set -run TestLeasesHaveCorrectData
+
+test-lease-set-expiration:
+	go test -v ./lib/common/lease_set -run TestNewestExpirationIsCorrect
+	go test -v ./lib/common/lease_set -run TestOldestExpirationIsCorrect
+
+.PHONY: test-lease-set-all \
+        test-lease-set-basic \
+        test-lease-set-leases \
+        test-lease-set-expiration

--- a/doc/tests/mapping.mk
+++ b/doc/tests/mapping.mk
@@ -1,0 +1,28 @@
+test-mapping-all: test-mapping-values test-mapping-duplicates test-mapping-conversion test-mapping-utils
+
+test-mapping-values:
+	go test -v ./lib/common/data -run TestValuesExclusesPairWithBadData
+	go test -v ./lib/common/data -run TestValuesWarnsMissingData
+	go test -v ./lib/common/data -run TestValuesWarnsExtraData
+	go test -v ./lib/common/data -run TestValuesEnforcesEqualDelimitor
+	go test -v ./lib/common/data -run TestValuesEnforcedSemicolonDelimitor
+	go test -v ./lib/common/data -run TestValuesReturnsValues
+
+test-mapping-duplicates:
+	go test -v ./lib/common/data -run TestHasDuplicateKeysTrueWhenDuplicates
+	go test -v ./lib/common/data -run TestHasDuplicateKeysFalseWithoutDuplicates
+	go test -v ./lib/common/data -run TestReadMappingHasDuplicateKeys
+
+test-mapping-conversion:
+	go test -v ./lib/common/data -run TestGoMapToMappingProducesCorrectMapping
+	go test -v ./lib/common/data -run TestFullGoMapToMappingProducesCorrectMapping
+
+test-mapping-utils:
+	go test -v ./lib/common/data -run TestStopValueRead
+	go test -v ./lib/common/data -run TestBeginsWith
+
+.PHONY: test-mapping-all \
+        test-mapping-values \
+        test-mapping-duplicates \
+        test-mapping-conversion \
+        test-mapping-utils

--- a/doc/tests/mapping_values.mk
+++ b/doc/tests/mapping_values.mk
@@ -1,0 +1,2 @@
+test-mapping-values-order:
+	go test -v ./lib/common/data -run TestMappingOrderSortsValuesThenKeys

--- a/doc/tests/noise.mk
+++ b/doc/tests/noise.mk
@@ -1,0 +1,11 @@
+test-noise-transport-all: test-noise-packet-encryption test-noise-transport-connection
+
+test-noise-packet-encryption:
+	go test -v ./lib/transport/noise -run TestEncryptDecryptPacketOffline
+
+test-noise-transport-connection:
+	go test -v ./lib/transport/noise -run TestTransport
+
+.PHONY: test-noise-transport-all \
+        test-noise-packet-encryption \
+        test-noise-transport-connection

--- a/doc/tests/router_address.mk
+++ b/doc/tests/router_address.mk
@@ -1,0 +1,19 @@
+test-router-address-all: test-router-address-validation test-router-address-functionality test-router-address-fuzz
+
+test-router-address-validation:
+	go test -v ./lib/common/router_address -run TestCheckValidReportsEmptySlice
+	go test -v ./lib/common/router_address -run TestCheckRouterAddressValidReportsDataMissing
+	go test -v ./lib/common/router_address -run TestCheckRouterAddressValidNoErrWithValidData
+
+test-router-address-functionality:
+	go test -v ./lib/common/router_address -run TestRouterAddressCostReturnsFirstByte
+	go test -v ./lib/common/router_address -run TestRouterAddressExpirationReturnsCorrectData
+	go test -v ./lib/common/router_address -run TestReadRouterAddressReturnsCorrectRemainderWithoutError
+
+test-router-address-fuzz:
+	go test -v ./lib/common/router_address -run TestCorrectsFuzzCrasher1
+
+.PHONY: test-router-address-all \
+        test-router-address-validation \
+        test-router-address-functionality \
+        test-router-address-fuzz

--- a/doc/tests/router_info.mk
+++ b/doc/tests/router_info.mk
@@ -1,0 +1,26 @@
+test-router-info-all: test-router-info-published test-router-info-addresses test-router-info-identity test-router-info-misc
+
+test-router-info-published:
+	go test -v ./lib/common/router_info -run TestPublishedReturnsCorrectDate
+	go test -v ./lib/common/router_info -run TestPublishedReturnsCorrectErrorWithPartialDate
+	go test -v ./lib/common/router_info -run TestPublishedReturnsCorrectErrorWithInvalidData
+
+test-router-info-addresses:
+	go test -v ./lib/common/router_info -run TestRouterAddressCountReturnsCorrectCount
+	go test -v ./lib/common/router_info -run TestRouterAddressCountReturnsCorrectErrorWithInvalidData
+	go test -v ./lib/common/router_info -run TestRouterAddressesReturnsAddresses
+	go test -v ./lib/common/router_info -run TestRouterAddressesReturnsAddressesWithMultiple
+
+test-router-info-identity:
+	go test -v ./lib/common/router_info -run TestRouterIdentityIsCorrect
+
+test-router-info-misc:
+	go test -v ./lib/common/router_info -run TestPeerSizeIsZero
+	go test -v ./lib/common/router_info -run TestOptionsAreCorrect
+	go test -v ./lib/common/router_info -run TestSignatureIsCorrectSize
+
+.PHONY: test-router-info-all \
+        test-router-info-published \
+        test-router-info-addresses \
+        test-router-info-identity \
+        test-router-info-misc

--- a/doc/tests/string.mk
+++ b/doc/tests/string.mk
@@ -1,0 +1,27 @@
+test-string-all: test-string-length test-string-data test-string-conversion test-string-read
+
+test-string-length:
+	go test -v ./lib/common/data -run TestStringReportsCorrectLength
+	go test -v ./lib/common/data -run TestI2PStringReportsLengthZeroError
+	go test -v ./lib/common/data -run TestI2PStringReportsExtraDataError
+	go test -v ./lib/common/data -run TestI2PStringDataReportsLengthZeroError
+
+test-string-data:
+	go test -v ./lib/common/data -run TestI2PStringDataReportsExtraDataError
+	go test -v ./lib/common/data -run TestI2PStringDataEmptyWhenZeroLength
+	go test -v ./lib/common/data -run TestI2PStringDataErrorWhenNonZeroLengthOnly
+
+test-string-conversion:
+	go test -v ./lib/common/data -run TestToI2PI2PStringFormatsCorrectly
+	go test -v ./lib/common/data -run TestToI2PStringReportsOverflows
+
+test-string-read:
+	go test -v ./lib/common/data -run TestReadStringReadsLength
+	go test -v ./lib/common/data -run TestReadI2PStringErrWhenEmptySlice
+	go test -v ./lib/common/data -run TestReadI2PStringErrWhenDataTooShort
+
+.PHONY: test-string-all \
+        test-string-length \
+        test-string-data \
+        test-string-conversion \
+        test-string-read

--- a/doc/tests/su3.mk
+++ b/doc/tests/su3.mk
@@ -1,0 +1,11 @@
+test-su3-all: test-su3-read test-su3-signature
+
+test-su3-read:
+	go test -v ./lib/su3 -run TestRead
+
+test-su3-signature:
+	go test -v ./lib/su3 -run TestReadSignatureFirst
+
+.PHONY: test-su3-all \
+        test-su3-read \
+        test-su3-signature

--- a/doc/tests/tunnel.mk
+++ b/doc/tests/tunnel.mk
@@ -1,0 +1,22 @@
+test-tunnel-all: test-tunnel-delivery-instructions test-tunnel-message
+
+# Tests from delivery_test.go
+test-tunnel-delivery-instructions:
+	go test -v ./lib/tunnel -run TestReadDeliveryInstructions
+
+# Tests from message_test.go
+test-tunnel-message: test-tunnel-message-padding test-tunnel-message-fragments
+
+test-tunnel-message-padding:
+	go test -v ./lib/tunnel -run TestDeliveryInstructionDataWithNoPadding
+	go test -v ./lib/tunnel -run TestDeliveryInstructionDataWithSomePadding
+	go test -v ./lib/tunnel -run TestDeliveryInstructionDataWithOnlyPadding
+
+test-tunnel-message-fragments:
+	go test -v ./lib/tunnel -run TestDeliveryInstructionsWithFragments
+
+.PHONY: test-tunnel-all \
+        test-tunnel-delivery-instructions \
+        test-tunnel-message \
+        test-tunnel-message-padding \
+        test-tunnel-message-fragments

--- a/lib/common/certificate/certificate.go
+++ b/lib/common/certificate/certificate.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/go-i2p/go-i2p/lib/common/data"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 // Certificate Types
 const (

--- a/lib/common/data/date.go
+++ b/lib/common/data/date.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 // DATE_SIZE is the length in bytes of an I2P Date.
 const DATE_SIZE = 8

--- a/lib/common/data/date_test.go
+++ b/lib/common/data/date_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTimeFromMiliseconds(t *testing.T) {
+func TestTimeFromMilliseconds(t *testing.T) {
 	assert := assert.New(t)
 
 	next_day := Date{0x00, 0x00, 0x00, 0x00, 0x05, 0x26, 0x5c, 0x00}

--- a/lib/common/destination/destination.go
+++ b/lib/common/destination/destination.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-i2p/go-i2p/lib/crypto"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 /*
 [Destination]

--- a/lib/common/key_certificate/key_certificate.go
+++ b/lib/common/key_certificate/key_certificate.go
@@ -38,7 +38,7 @@ import (
 	"github.com/go-i2p/go-i2p/lib/crypto"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 // Key Certificate Signing Key Types
 const (

--- a/lib/common/keys_and_cert/keys_and_cert.go
+++ b/lib/common/keys_and_cert/keys_and_cert.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 // Sizes of various KeysAndCert structures and requirements
 const (

--- a/lib/common/lease_set/lease_set.go
+++ b/lib/common/lease_set/lease_set.go
@@ -17,7 +17,7 @@ import (
 	"github.com/go-i2p/go-i2p/lib/crypto"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 // Sizes of various structures in an I2P LeaseSet
 const (

--- a/lib/common/router_address/router_address.go
+++ b/lib/common/router_address/router_address.go
@@ -19,7 +19,7 @@ const (
 	ROUTER_ADDRESS_MIN_SIZE = 9
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 /*
 [RouterAddress]

--- a/lib/common/router_identity/router_identity.go
+++ b/lib/common/router_identity/router_identity.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 /*
 [RouterIdentity]

--- a/lib/common/router_info/router_info.go
+++ b/lib/common/router_info/router_info.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/go-i2p/go-i2p/lib/common/signature"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 const ROUTER_INFO_MIN_SIZE = 439
 

--- a/lib/common/session_tag/session_tag.go
+++ b/lib/common/session_tag/session_tag.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 /*
 [SessionKey]

--- a/lib/common/signature/signature.go
+++ b/lib/common/signature/signature.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 // Lengths of signature keys
 const (

--- a/lib/crypto/aes.go
+++ b/lib/crypto/aes.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 // AESSymmetricKey represents a symmetric key for AES encryption/decryption
 type AESSymmetricKey struct {

--- a/lib/crypto/aes_test.go
+++ b/lib/crypto/aes_test.go
@@ -6,8 +6,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"testing"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func TestAESEncryptDecrypt(t *testing.T) {

--- a/lib/crypto/dsa_test.go
+++ b/lib/crypto/dsa_test.go
@@ -4,8 +4,6 @@ import (
 	"crypto/rand"
 	"io"
 	"testing"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func TestDSA(t *testing.T) {

--- a/lib/crypto/elg_test.go
+++ b/lib/crypto/elg_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/openpgp/elgamal"
 )
 

--- a/lib/i2np/build_request_record.go
+++ b/lib/i2np/build_request_record.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-i2p/go-i2p/lib/util/logger"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 /*
 I2P I2NP BuildRequestRecord

--- a/lib/netdb/reseed/reseed.go
+++ b/lib/netdb/reseed/reseed.go
@@ -18,7 +18,7 @@ import (
 	"github.com/go-i2p/go-i2p/lib/su3"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 const (
 	I2pUserAgent = "Wget/1.11.4"

--- a/lib/netdb/std.go
+++ b/lib/netdb/std.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-i2p/go-i2p/lib/util"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 // standard network database implementation using local filesystem skiplist
 type StdNetDB struct {

--- a/lib/router/router.go
+++ b/lib/router/router.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-i2p/go-i2p/lib/netdb"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 // i2p router type
 type Router struct {

--- a/lib/su3/su3.go
+++ b/lib/su3/su3.go
@@ -83,7 +83,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 type SignatureType string
 

--- a/lib/transport/multi.go
+++ b/lib/transport/multi.go
@@ -6,7 +6,7 @@ import (
 	"github.com/go-i2p/go-i2p/lib/util/logger"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 // muxes multiple transports into 1 Transport
 // implements transport.Transport

--- a/lib/transport/noise/handshake.go
+++ b/lib/transport/noise/handshake.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-i2p/go-i2p/lib/common/router_info"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 func (c *NoiseTransport) Handshake(routerInfo router_info.RouterInfo) error {
 	log.WithField("router_info", routerInfo.IdentHash()).Debug("Starting Noise handshake")

--- a/lib/tunnel/delivery.go
+++ b/lib/tunnel/delivery.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 /*
 I2P First Fragment Delivery Instructions

--- a/lib/util/logger/log.go
+++ b/lib/util/logger/log.go
@@ -14,7 +14,7 @@ var (
 	once sync.Once
 )
 
-func InitializeLogger() {
+func InitializeGoI2PLogger() {
 	once.Do(func() {
 		log = logrus.New()
 		// We do not want to log by default
@@ -38,14 +38,14 @@ func InitializeLogger() {
 	})
 }
 
-// GetLogger returns the initialized logger
-func GetLogger() *logrus.Logger {
+// GetGoI2PLogger returns the initialized logger
+func GetGoI2PLogger() *logrus.Logger {
 	if log == nil {
-		InitializeLogger()
+		InitializeGoI2PLogger()
 	}
 	return log
 }
 
 func init() {
-	InitializeLogger()
+	InitializeGoI2PLogger()
 }

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-i2p/go-i2p/lib/util/signals"
 )
 
-var log = logger.GetLogger()
+var log = logger.GetGoI2PLogger()
 
 func main() {
 	netDbPath := flag.String("netDb", config.DefaultNetDbConfig.Path, "Path to the netDb")


### PR DESCRIPTION
Wrote makefile tests for fine tuned tests.

Edit: Mixed this into here because it's a bit urgent, there is a naming collision that conflicts with the same logging paradigm found in i2pkeys and sam3. So we require renaming the logger functions in order for the libs to work together.