### PR TITLE
Fix key certificate tests

### DIFF
--- a/lib/common/key_certificate/key_certificate.go
+++ b/lib/common/key_certificate/key_certificate.go
@@ -303,7 +303,6 @@ func NewKeyCertificate(bytes []byte) (key_certificate *KeyCertificate, remainder
 	}
 	if len(bytes) < KEYCERT_MIN_SIZE {
 		err = errors.New("error parsing key certificate: not enough data")
-		remainder = bytes[KEYCERT_MIN_SIZE:]
 		log.WithError(err).Error("KeyCertificate data too short")
 	}
 	key_certificate = &KeyCertificate{

--- a/lib/common/key_certificate/key_certificate_test.go
+++ b/lib/common/key_certificate/key_certificate_test.go
@@ -123,7 +123,7 @@ func TestConstructSigningPublicKeyWithP521(t *testing.T) {
 	assert := assert.New(t)
 
 	key_cert, _, err := NewKeyCertificate([]byte{0x05, 0x00, 0x08, 0x00, 0x03, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00})
-	data := make([]byte, 128)
+	data := make([]byte, 132)
 	spk, err := key_cert.ConstructSigningPublicKey(data)
 
 	assert.Nil(err, "ConstructSigningPublicKey() with P521 returned err on valid data")


### PR DESCRIPTION
That's all to get the `key_certificate` tests working, should I also implement the renames and rewrites that PR #5 was intended to do?