### PR TITLE
ntcp/session.go: fixes and imrovements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.step.sm/crypto v0.58.1
 	golang.org/x/crypto v0.35.0
-	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -43,6 +42,7 @@ require (
 	go.opentelemetry.io/otel v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect


### PR DESCRIPTION
- Stop using deprecated (and probably not cryptographically secure) exp/rand, switch to crypto/rand instead
- Reduce code duplicacy by defining `buildAesStaticKey()` method
- Properly handle pointer to `crypto.AESSymmetricKey` struct to prevent nil pointer dereferences
- go mod tidy