### PR TITLE
Better config file handling

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -17,14 +17,13 @@ var (
 const GOI2P_BASE_DIR = ".go-i2p"
 
 func InitConfig() {
-	defaultConfigDir := filepath.Join(util.UserHome(), GOI2P_BASE_DIR)
 
 	if CfgFile != "" {
 		// Use config file from the flag
 		viper.SetConfigFile(CfgFile)
 	} else {
-		// Set up viper to use the default config file: $HOME/.go-ip/config.yaml
-		viper.AddConfigPath(defaultConfigDir)
+		// Set up viper to use the default config path $HOME/.go-ip/
+		viper.AddConfigPath(BuildI2PDirPath())
 		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
 	}
@@ -32,19 +31,8 @@ func InitConfig() {
 	// Load defaults
 	setDefaults()
 
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			if CfgFile != "" {
-				log.Fatalf("Config file %s is not found: %s", CfgFile, err)
-			} else {
-				createDefaultConfig(defaultConfigDir)
-			}
-		} else {
-			log.Fatalf("Error reading config file: %s", err)
-		}
-	} else {
-		log.Debugf("Using config file: %s", viper.ConfigFileUsed())
-	}
+	// handle config file creating if needed
+	handleConfigFile()
 
 	// Update RouterConfigProperties
 	UpdateRouterConfig()
@@ -101,4 +89,25 @@ func createDefaultConfig(defaultConfigDir string) {
 
 	log.Debugf("Created default configuration at: %s", defaultConfigFile)
 
+}
+
+func handleConfigFile() {
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			if CfgFile != "" {
+				log.Fatalf("Config file %s is not found: %s", CfgFile, err)
+			} else {
+				createDefaultConfig(BuildI2PDirPath())
+			}
+		} else {
+			log.Fatalf("Error reading config file: %s", err)
+		}
+	} else {
+		log.Debugf("Using config file: %s", viper.ConfigFileUsed())
+	}
+
+}
+
+func BuildI2PDirPath() string {
+	return filepath.Join(util.UserHome(), GOI2P_BASE_DIR)
 }

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -31,7 +31,7 @@ func InitConfig() {
 	// Load defaults
 	setDefaults()
 
-	// handle config file creating if needed
+	// handle config file creating it if needed
 	handleConfigFile()
 
 	// Update RouterConfigProperties

--- a/lib/config/router.go
+++ b/lib/config/router.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
+
+	"github.com/go-i2p/go-i2p/lib/util"
 )
 
 // router.config options
@@ -17,20 +18,12 @@ type RouterConfig struct {
 	Bootstrap *BootstrapConfig
 }
 
-func home() string {
-	h, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
-	return h
-}
-
 func defaultBase() string {
-	return filepath.Join(home(), GOI2P_BASE_DIR, "base")
+	return filepath.Join(util.UserHome(), GOI2P_BASE_DIR, "base")
 }
 
 func defaultConfig() string {
-	return filepath.Join(home(), GOI2P_BASE_DIR, "config")
+	return filepath.Join(util.UserHome(), GOI2P_BASE_DIR, "config")
 }
 
 // defaults for router

--- a/lib/config/router.go
+++ b/lib/config/router.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"path/filepath"
-
-	"github.com/go-i2p/go-i2p/lib/util"
 )
 
 // router.config options
@@ -19,11 +17,11 @@ type RouterConfig struct {
 }
 
 func defaultBase() string {
-	return filepath.Join(util.UserHome(), GOI2P_BASE_DIR, "base")
+	return filepath.Join(BuildI2PDirPath(), "base")
 }
 
 func defaultConfig() string {
-	return filepath.Join(util.UserHome(), GOI2P_BASE_DIR, "config")
+	return filepath.Join(BuildI2PDirPath(), "config")
 }
 
 // defaults for router

--- a/lib/util/home.go
+++ b/lib/util/home.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"log"
+	"os"
+)
+
+func UserHome() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("Unable to get current user's home directory. $HOME environment variable issue? %s", err)
+	}
+
+	return homeDir
+}


### PR DESCRIPTION
- Replace low level file operations with viper equivalents: file existence checks, reading, writing.
- Split out default config saving routine into  `createDefaultConfig()` func. Utilize `viper.WriteConfig()`, which allows to re-use already defined at this point default settings. Drop unused now `defaultConfig` struct and yaml marshalling.
- Create helper `util.UserHome()` to reduce duplicacy.
- Handle errors returned by `viper.ReadInConfig()` based on their type and taking into account whether or not we are dealing with config path provided via args.
- General readability (or at least that was the intention).