### PR TITLE
Fix: Using  `SafeWriteConfig` when creating a new config file is needed

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -233,7 +233,7 @@ func createDefaultConfig(defaultConfigDir string) {
 	}
 
 	// Write current config file
-	if err := viper.WriteConfig(); err != nil {
+	if err := viper.SafeWriteConfig(); err != nil {
 		log.Fatalf("Could not write default config file: %s", err)
 	}
 


### PR DESCRIPTION
Use SafeWriteConfig() instead of WriteConfig(). If a new user is setting up a environment, safeconfig ensures that it creates a configuration file and then writes to. This ensures we do not get any write errors.