### PR TITLE
fix: `file_validation_test.go`

### DIFF
--- a/lib/netdb/file_validation_test.go
+++ b/lib/netdb/file_validation_test.go
@@ -143,6 +143,12 @@ func TestCheckFilePathValid_AbsolutePath(t *testing.T) {
 // TestCheckFilePathValid_RelativePath tests handling of relative paths
 func TestCheckFilePathValid_RelativePath(t *testing.T) {
 	tmpDir := t.TempDir()
+
+	// Resolve symlinks to handle macOS /var -> /private/var
+	if resolved, err := filepath.EvalSymlinks(tmpDir); err == nil {
+		tmpDir = resolved
+	}
+
 	db := NewStdNetDB(tmpDir)
 	require.NoError(t, db.Ensure())
 


### PR DESCRIPTION
Error with temp directory creating and expected macOS file path prefix. 

/var -> /private/var