### PR TITLE
use allocated ntcp port if we have one

### DIFF
--- a/lib/router/router.go
+++ b/lib/router/router.go
@@ -263,7 +263,12 @@ func constructRouterInfo(r *Router) (*router_info.RouterInfo, error) {
 
 // buildNTCP2Transport creates the NTCP2 transport, publishes its address to ri, and returns it.
 func buildNTCP2Transport(r *Router, ri *router_info.RouterInfo) (*ntcp.NTCP2Transport, error) {
-	ntcp2Config, err := ntcp.NewConfig(":0") // Use port 0 for automatic assignment
+	port := 0 // default: automatic assignment
+	if r.cfg.Transport != nil && r.cfg.Transport.NTCP2Port > 0 {
+		port = r.cfg.Transport.NTCP2Port
+	}
+	addr := fmt.Sprintf(":%d", port)
+	ntcp2Config, err := ntcp.NewConfig(addr)
 	if err != nil {
 		log.WithError(err).Error("Failed to create NTCP2 config")
 		return nil, err


### PR DESCRIPTION
The hardcoded ntcp2 listen address seems to impact NAT, it was always ending up using the fallback and produced the below error:

```Failed to create router: auto-configure failed: failed to create router: failed to create TCP listener: failed to create port mapping: invalid port number: 0 (must be 1-65535)```

This MR just reproduces the setup that SSU2 does in the function below