### PR TITLE
Add package boilerplate: errors.go and constants.go for netdb and naming

### DIFF
--- a/lib/naming/constants.go
+++ b/lib/naming/constants.go
@@ -1,0 +1,21 @@
+package naming
+
+import "time"
+
+// B32AddressLength is the length of a base32-encoded I2P address
+// excluding the ".b32.i2p" suffix. 256 bits encoded in base32
+// produces 52 characters.
+const B32AddressLength = 52
+
+// B32HashSize is the size in bytes of the SHA-256 hash used in
+// .b32.i2p addresses.
+const B32HashSize = 32
+
+// DefaultFetchTimeout is the maximum time to wait for a NetDB
+// LeaseSet lookup before returning a timeout error.
+const DefaultFetchTimeout = 10 * time.Second
+
+// MaxSubscriptionSize is the maximum number of entries allowed
+// in a single address book subscription to prevent memory
+// exhaustion from overly large hosts files.
+const MaxSubscriptionSize = 10000

--- a/lib/naming/errors.go
+++ b/lib/naming/errors.go
@@ -1,0 +1,23 @@
+package naming
+
+import "errors"
+
+// ErrHostnameNotFound is returned when a hostname is not found in the
+// resolver's hosts map.
+var ErrHostnameNotFound = errors.New("hostname not found")
+
+// ErrEmptyHostname is returned when an empty hostname is passed to
+// a resolution function.
+var ErrEmptyHostname = errors.New("empty hostname")
+
+// ErrInvalidB32Length is returned when a .b32.i2p address does not have
+// the expected 52-character base32 encoding.
+var ErrInvalidB32Length = errors.New("invalid b32 address length")
+
+// ErrResolverNotInitialized is returned when an operation requires the
+// resolver to be initialized but it has not been created yet.
+var ErrResolverNotInitialized = errors.New("resolver not initialized")
+
+// ErrInvalidBase64Destination is returned when the base64-encoded
+// destination in a hosts.txt line cannot be decoded.
+var ErrInvalidBase64Destination = errors.New("invalid base64 destination")

--- a/lib/netdb/constants.go
+++ b/lib/netdb/constants.go
@@ -1,0 +1,46 @@
+package netdb
+
+import "time"
+
+// Peer profile persistence configuration.
+
+// PeerProfileFileName is the filename used to persist peer tracking
+// statistics to disk. The file is stored in the NetDB directory.
+const PeerProfileFileName = "peer_profiles.json"
+
+// DefaultPeerProfileExpiration is how long a peer profile entry survives
+// without any new activity before it is discarded on load. Matches i2pd's
+// PEER_PROFILE_EXPIRATION_TIMEOUT (36 hours).
+const DefaultPeerProfileExpiration = 36 * time.Hour
+
+// DefaultPeerProfilePersistInterval is how often the PeerTracker saves
+// its in-memory statistics to disk during normal operation.
+const DefaultPeerProfilePersistInterval = 5 * time.Minute
+
+// Peer reliability threshold constants.
+
+// LowSuccessRateThreshold is the success rate below which a peer is
+// considered stale. Used by PeerTracker.IsLikelyStale.
+const LowSuccessRateThreshold = 0.25
+
+// HighSuccessRateThreshold is the success rate above which a peer is
+// considered reliable. Used by PeerTracker.GetReliablePeers.
+const HighSuccessRateThreshold = 0.75
+
+// MinAttemptsForStats is the minimum number of connection attempts
+// before a peer's success rate is considered statistically meaningful.
+const MinAttemptsForStats = 5
+
+// ConsecutiveFailThreshold is the number of consecutive failures that
+// triggers automatic staleness classification.
+const ConsecutiveFailThreshold = 3
+
+// EMAAlpha is the exponential moving average smoothing factor used
+// for response time tracking. A value of 0.2 gives new samples 20%
+// weight, providing a stable average that smoothly adapts to changing
+// network conditions without being overly reactive to outliers.
+const EMAAlpha = 0.2
+
+// StalenessCheckWindow is the lookback window for the "recent failures
+// without recent success" staleness check in PeerTracker.
+const StalenessCheckWindow = 1 * time.Hour

--- a/lib/netdb/errors.go
+++ b/lib/netdb/errors.go
@@ -1,0 +1,20 @@
+package netdb
+
+import "errors"
+
+// ErrNoPeerData is returned when no peer tracking data is available
+// for the requested hash in the PeerTracker.
+var ErrNoPeerData = errors.New("no peer data available")
+
+// ErrInvalidPeerHash is returned when a peer hash is zero or does not
+// match the expected format (32-byte SHA-256 hash).
+var ErrInvalidPeerHash = errors.New("invalid peer hash")
+
+// ErrCorruptedProfiles is returned when persisted peer profile data
+// cannot be loaded or parsed, typically due to disk corruption or
+// incompatible format changes.
+var ErrCorruptedProfiles = errors.New("corrupted peer profiles")
+
+// ErrNetDBNotInitialized is returned when an operation requires the
+// NetDB to be initialized but it has not been created or started yet.
+var ErrNetDBNotInitialized = errors.New("netdb not initialized")


### PR DESCRIPTION
## Summary

Add sentinel errors and exported constants to `lib/netdb` and `lib/naming`, following the boilerplate patterns already established in other packages (`lib/transport/errors.go`, `lib/i2np/constants.go`).

## Changes

### `lib/netdb/errors.go` (new)
- `ErrNoPeerData` — no peer tracking data available
- `ErrInvalidPeerHash` — zero or malformed hash
- `ErrCorruptedProfiles` — persisted profiles failed to load
- `ErrNetDBNotInitialized` — operation on uninitialized NetDB

### `lib/netdb/constants.go` (new)
- Profile persistence: `PeerProfileFileName`, `DefaultPeerProfileExpiration` (36h, matches i2pd), `DefaultPeerProfilePersistInterval`
- Threshold constants: `LowSuccessRateThreshold`, `HighSuccessRateThreshold`, `MinAttemptsForStats`, `ConsecutiveFailThreshold`
- `EMAAlpha` (0.2), `StalenessCheckWindow` (1h)

### `lib/naming/errors.go` (new)
- `ErrHostnameNotFound`, `ErrEmptyHostname`, `ErrInvalidB32Length`, `ErrResolverNotInitialized`, `ErrInvalidBase64Destination`

### `lib/naming/constants.go` (new)
- `B32AddressLength` (52), `B32HashSize` (32)
- `DefaultFetchTimeout`, `MaxSubscriptionSize`

## Conventions
- Sentinel errors use `errors.New` (not oops) so callers can use `errors.Is()`, matching the pattern in `lib/transport/errors.go` and `lib/i2np/constants.go`
- Exported constants use MixedCaps (matching existing conventions: `StandardBuildRecordSize`, `DefaultExpirationTolerance`)
- All constants have godoc comments

Refs: #46