### PR TITLE
netdb, naming: add errors.go and constants.go boilerplate

### DIFF
--- a/lib/naming/constants.go
+++ b/lib/naming/constants.go
@@ -1,0 +1,24 @@
+package naming
+
+import "time"
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Address format constants
+// ──────────────────────────────────────────────────────────────────────────────
+
+// B32AddressLength is the length of a base32-encoded I2P address
+// excluding the ".b32.i2p" suffix. 256 bits encoded in base32
+// produces 52 characters.
+const B32AddressLength = 52
+
+// B32HashSize is the size in bytes of the SHA-256 hash used in
+// .b32.i2p addresses.
+const B32HashSize = 32
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Network operation constants
+// ──────────────────────────────────────────────────────────────────────────────
+
+// DefaultFetchTimeout is the maximum time to wait for a NetDB
+// LeaseSet lookup before returning a timeout error.
+const DefaultFetchTimeout = 10 * time.Second

--- a/lib/naming/errors.go
+++ b/lib/naming/errors.go
@@ -13,11 +13,3 @@ var ErrEmptyHostname = errors.New("empty hostname")
 // ErrInvalidB32Length is returned when a .b32.i2p address does not have
 // the expected 52-character base32 encoding.
 var ErrInvalidB32Length = errors.New("invalid b32 address length")
-
-// ErrResolverNotInitialized is returned when an operation requires the
-// resolver to be initialized but it has not been created yet.
-var ErrResolverNotInitialized = errors.New("resolver not initialized")
-
-// ErrInvalidBase64Destination is returned when the base64-encoded
-// destination in a hosts.txt line cannot be decoded.
-var ErrInvalidBase64Destination = errors.New("invalid base64 destination")

--- a/lib/naming/errors.go
+++ b/lib/naming/errors.go
@@ -1,0 +1,23 @@
+package naming
+
+import "errors"
+
+// ErrHostnameNotFound is returned when a hostname is not found in the
+// resolver's hosts map.
+var ErrHostnameNotFound = errors.New("hostname not found")
+
+// ErrEmptyHostname is returned when an empty hostname is passed to
+// a resolution function.
+var ErrEmptyHostname = errors.New("empty hostname")
+
+// ErrInvalidB32Length is returned when a .b32.i2p address does not have
+// the expected 52-character base32 encoding.
+var ErrInvalidB32Length = errors.New("invalid b32 address length")
+
+// ErrResolverNotInitialized is returned when an operation requires the
+// resolver to be initialized but it has not been created yet.
+var ErrResolverNotInitialized = errors.New("resolver not initialized")
+
+// ErrInvalidBase64Destination is returned when the base64-encoded
+// destination in a hosts.txt line cannot be decoded.
+var ErrInvalidBase64Destination = errors.New("invalid base64 destination")

--- a/lib/naming/errors_test.go
+++ b/lib/naming/errors_test.go
@@ -12,14 +12,10 @@ func TestSentinelErrorsAreNonNull(t *testing.T) {
 	assert.NotNil(t, ErrHostnameNotFound)
 	assert.NotNil(t, ErrEmptyHostname)
 	assert.NotNil(t, ErrInvalidB32Length)
-	assert.NotNil(t, ErrResolverNotInitialized)
-	assert.NotNil(t, ErrInvalidBase64Destination)
 
 	assert.NotEmpty(t, ErrHostnameNotFound.Error())
 	assert.NotEmpty(t, ErrEmptyHostname.Error())
 	assert.NotEmpty(t, ErrInvalidB32Length.Error())
-	assert.NotEmpty(t, ErrResolverNotInitialized.Error())
-	assert.NotEmpty(t, ErrInvalidBase64Destination.Error())
 }
 
 // TestAddressConstantsAreCorrect verifies that B32 address constants

--- a/lib/naming/errors_test.go
+++ b/lib/naming/errors_test.go
@@ -1,0 +1,35 @@
+package naming
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSentinelErrorsAreNonNull verifies that sentinel errors are properly
+// defined and not empty strings.
+func TestSentinelErrorsAreNonNull(t *testing.T) {
+	assert.NotNil(t, ErrHostnameNotFound)
+	assert.NotNil(t, ErrEmptyHostname)
+	assert.NotNil(t, ErrInvalidB32Length)
+	assert.NotNil(t, ErrResolverNotInitialized)
+	assert.NotNil(t, ErrInvalidBase64Destination)
+
+	assert.NotEmpty(t, ErrHostnameNotFound.Error())
+	assert.NotEmpty(t, ErrEmptyHostname.Error())
+	assert.NotEmpty(t, ErrInvalidB32Length.Error())
+	assert.NotEmpty(t, ErrResolverNotInitialized.Error())
+	assert.NotEmpty(t, ErrInvalidBase64Destination.Error())
+}
+
+// TestAddressConstantsAreCorrect verifies that B32 address constants
+// match the I2P specification.
+func TestAddressConstantsAreCorrect(t *testing.T) {
+	assert.Equal(t, 52, B32AddressLength, "256 bits in base32 = 52 chars")
+	assert.Equal(t, 32, B32HashSize, "SHA-256 produces 32 bytes")
+}
+
+// TestDefaultFetchTimeoutIsPositive verifies the fetch timeout is reasonable.
+func TestDefaultFetchTimeoutIsPositive(t *testing.T) {
+	assert.Positive(t, DefaultFetchTimeout)
+}

--- a/lib/netdb/constants.go
+++ b/lib/netdb/constants.go
@@ -1,0 +1,33 @@
+package netdb
+
+import "time"
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Peer reliability threshold constants
+// ──────────────────────────────────────────────────────────────────────────────
+
+// LowSuccessRateThreshold is the success rate below which a peer is
+// considered stale. Used by PeerTracker.IsLikelyStale.
+const LowSuccessRateThreshold = 0.25
+
+// HighSuccessRateThreshold is the success rate above which a peer is
+// considered reliable. Used by PeerTracker.GetReliablePeers.
+const HighSuccessRateThreshold = 0.75
+
+// MinAttemptsForStats is the minimum number of connection attempts
+// before a peer's success rate is considered statistically meaningful.
+const MinAttemptsForStats = 5
+
+// ConsecutiveFailThreshold is the number of consecutive failures that
+// triggers automatic staleness classification.
+const ConsecutiveFailThreshold = 3
+
+// EMAAlpha is the exponential moving average smoothing factor used
+// for response time tracking. A value of 0.2 gives new samples 20%
+// weight, providing a stable average that smoothly adapts to changing
+// network conditions without being overly reactive to outliers.
+const EMAAlpha = 0.2
+
+// StalenessCheckWindow is the lookback window for the "recent failures
+// without recent success" staleness check in PeerTracker.
+const StalenessCheckWindow = 1 * time.Hour

--- a/lib/netdb/errors.go
+++ b/lib/netdb/errors.go
@@ -9,12 +9,3 @@ var ErrNoPeerData = errors.New("no peer data available")
 // ErrInvalidPeerHash is returned when a peer hash is zero or does not
 // match the expected format (32-byte SHA-256 hash).
 var ErrInvalidPeerHash = errors.New("invalid peer hash")
-
-// ErrCorruptedProfiles is returned when persisted peer profile data
-// cannot be loaded or parsed, typically due to disk corruption or
-// incompatible format changes.
-var ErrCorruptedProfiles = errors.New("corrupted peer profiles")
-
-// ErrNetDBNotInitialized is returned when an operation requires the
-// NetDB to be initialized but it has not been created or started yet.
-var ErrNetDBNotInitialized = errors.New("netdb not initialized")

--- a/lib/netdb/errors.go
+++ b/lib/netdb/errors.go
@@ -1,0 +1,20 @@
+package netdb
+
+import "errors"
+
+// ErrNoPeerData is returned when no peer tracking data is available
+// for the requested hash in the PeerTracker.
+var ErrNoPeerData = errors.New("no peer data available")
+
+// ErrInvalidPeerHash is returned when a peer hash is zero or does not
+// match the expected format (32-byte SHA-256 hash).
+var ErrInvalidPeerHash = errors.New("invalid peer hash")
+
+// ErrCorruptedProfiles is returned when persisted peer profile data
+// cannot be loaded or parsed, typically due to disk corruption or
+// incompatible format changes.
+var ErrCorruptedProfiles = errors.New("corrupted peer profiles")
+
+// ErrNetDBNotInitialized is returned when an operation requires the
+// NetDB to be initialized but it has not been created or started yet.
+var ErrNetDBNotInitialized = errors.New("netdb not initialized")

--- a/lib/netdb/errors_test.go
+++ b/lib/netdb/errors_test.go
@@ -1,0 +1,35 @@
+package netdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSentinelErrorsAreNonNull verifies that sentinel errors are properly
+// defined and not empty strings.
+func TestSentinelErrorsAreNonNull(t *testing.T) {
+	assert.NotNil(t, ErrNoPeerData)
+	assert.NotNil(t, ErrInvalidPeerHash)
+	assert.NotNil(t, ErrCorruptedProfiles)
+	assert.NotNil(t, ErrNetDBNotInitialized)
+
+	assert.NotEmpty(t, ErrNoPeerData.Error())
+	assert.NotEmpty(t, ErrInvalidPeerHash.Error())
+	assert.NotEmpty(t, ErrCorruptedProfiles.Error())
+	assert.NotEmpty(t, ErrNetDBNotInitialized.Error())
+}
+
+// TestThresholdConstantsArePositive verifies that threshold constants
+// have sensible values.
+func TestThresholdConstantsArePositive(t *testing.T) {
+	assert.Greater(t, LowSuccessRateThreshold, 0.0)
+	assert.Less(t, LowSuccessRateThreshold, 1.0)
+	assert.Greater(t, HighSuccessRateThreshold, 0.0)
+	assert.Less(t, HighSuccessRateThreshold, 1.0)
+	assert.Greater(t, MinAttemptsForStats, 0)
+	assert.Greater(t, ConsecutiveFailThreshold, 0)
+	assert.Greater(t, EMAAlpha, 0.0)
+	assert.Less(t, EMAAlpha, 1.0)
+	assert.Positive(t, StalenessCheckWindow)
+}

--- a/lib/netdb/errors_test.go
+++ b/lib/netdb/errors_test.go
@@ -11,13 +11,9 @@ import (
 func TestSentinelErrorsAreNonNull(t *testing.T) {
 	assert.NotNil(t, ErrNoPeerData)
 	assert.NotNil(t, ErrInvalidPeerHash)
-	assert.NotNil(t, ErrCorruptedProfiles)
-	assert.NotNil(t, ErrNetDBNotInitialized)
 
 	assert.NotEmpty(t, ErrNoPeerData.Error())
 	assert.NotEmpty(t, ErrInvalidPeerHash.Error())
-	assert.NotEmpty(t, ErrCorruptedProfiles.Error())
-	assert.NotEmpty(t, ErrNetDBNotInitialized.Error())
 }
 
 // TestThresholdConstantsArePositive verifies that threshold constants

--- a/lib/netdb/peer_tracker.go
+++ b/lib/netdb/peer_tracker.go
@@ -244,7 +244,7 @@ func (pt *PeerTracker) hasLowSuccessRate(stats *PeerStats, hash common.Hash) boo
 // hasRecentFailuresWithoutSuccess checks if the peer has recent failures with no recent successes.
 // Returns true if peer has consecutive failures in the last hour but no success in that period.
 func (pt *PeerTracker) hasRecentFailuresWithoutSuccess(stats *PeerStats, hash common.Hash) bool {
-	hourAgo := time.Now().Add(-1 * time.Hour)
+	hourAgo := time.Now().Add(-StalenessCheckWindow)
 	if stats.ConsecutiveFails >= consecutiveFailThreshold && !stats.LastFailure.IsZero() && stats.LastFailure.After(hourAgo) {
 		if stats.LastSuccess.IsZero() || stats.LastSuccess.Before(hourAgo) {
 			log.WithFields(logger.Fields{
@@ -407,7 +407,7 @@ func isStaleUnlocked(stats *PeerStats) bool {
 		}
 	}
 	// Recent failures without recent success
-	hourAgo := time.Now().Add(-1 * time.Hour)
+	hourAgo := time.Now().Add(-StalenessCheckWindow)
 	if stats.ConsecutiveFails >= consecutiveFailThreshold && !stats.LastFailure.IsZero() && stats.LastFailure.After(hourAgo) {
 		if stats.LastSuccess.IsZero() || stats.LastSuccess.Before(hourAgo) {
 			return true

--- a/lib/netdb/peer_tracker.go
+++ b/lib/netdb/peer_tracker.go
@@ -408,7 +408,7 @@ func isStaleUnlocked(stats *PeerStats) bool {
 	}
 	// Recent failures without recent success
 	hourAgo := time.Now().Add(-1 * time.Hour)
-	if stats.ConsecutiveFails >= 3 && !stats.LastFailure.IsZero() && stats.LastFailure.After(hourAgo) {
+	if stats.ConsecutiveFails >= consecutiveFailThreshold && !stats.LastFailure.IsZero() && stats.LastFailure.After(hourAgo) {
 		if stats.LastSuccess.IsZero() || stats.LastSuccess.Before(hourAgo) {
 			return true
 		}

--- a/lib/netdb/std.go
+++ b/lib/netdb/std.go
@@ -1418,7 +1418,7 @@ func (db *StdNetDB) GetActivePeerCount() int {
 		return 0
 	}
 
-	hourAgo := time.Now().Add(-1 * time.Hour)
+	hourAgo := time.Now().Add(-StalenessCheckWindow)
 	count := 0
 
 	// Iterate through all tracked peers and count those with recent successful connections


### PR DESCRIPTION
`lib/netdb` and `lib/naming` are missing sentinel errors and exported constants, making it hard for callers to do `errors.Is()` checks or reference configuration values. This adds them, following patterns already used in `lib/transport/errors.go` and `lib/i2np/constants.go`.

## What's added

**lib/netdb/errors.go** — 2 sentinel errors:
- `ErrNoPeerData` — no peer tracking data available
- `ErrInvalidPeerHash` — zero or malformed hash

**lib/netdb/constants.go** — 6 exported constants, extracted from existing inline values in `peer_tracker.go`:
- `LowSuccessRateThreshold`, `HighSuccessRateThreshold`, `MinAttemptsForStats`, `ConsecutiveFailThreshold`, `EMAAlpha`, `StalenessCheckWindow`

**lib/naming/errors.go** — 3 sentinel errors:
- `ErrHostnameNotFound`, `ErrEmptyHostname`, `ErrInvalidB32Length`

**lib/naming/constants.go** — 3 exported constants, extracted from `resolver.go`:
- `B32AddressLength`, `B32HashSize`, `DefaultFetchTimeout`

## Bug fix

`isStaleUnlocked()` was using a hardcoded `3` instead of the existing `consecutiveFailThreshold` constant — fixed that.

## Notes

- Only included errors and constants that map to existing code — no speculative additions
- The unexported constants in `peer_tracker.go` are still there; switching them to reference the exported versions can be a follow-up PR to keep this one focused
- Tests included, gofumpt / go vet / go test all pass

Closes #46
