### PR TITLE
feat(naming): add SubscriptionManager for remote hosts.txt fetching

### DIFF
--- a/lib/naming/subscription.go
+++ b/lib/naming/subscription.go
@@ -1,0 +1,353 @@
+package naming
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-i2p/logger"
+	"github.com/samber/oops"
+)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Subscription types
+// ──────────────────────────────────────────────────────────────────────────────
+
+// defaultSubscriptionInterval is the default fetch interval for subscriptions
+// that do not specify one. Matches i2pd's default of 12 hours.
+const defaultSubscriptionInterval = 12 * time.Hour
+
+// maxSubscriptionBody is the maximum size of a remote hosts.txt response.
+const maxSubscriptionBody = 1 << 20 // 1 MiB
+
+// Subscription represents a remote hosts.txt source that is fetched
+// periodically and merged into the resolver.
+type Subscription struct {
+	URL      string
+	Name     string
+	Interval time.Duration
+}
+
+// SubscriptionManager periodically fetches remote hosts.txt files and
+// merges entries into a HostsTxtResolver.
+//
+// Each subscription runs on an independent goroutine with its own
+// ticker. HTTP errors are logged but never fatal — the manager
+// continues fetching other sources and retries on the next tick.
+type SubscriptionManager struct {
+	mu            sync.Mutex
+	subscriptions map[string]*Subscription // keyed by URL
+	resolver      *HostsTxtResolver
+	client        *http.Client
+	ctx           context.Context
+	cancel        context.CancelFunc
+	wg            sync.WaitGroup
+}
+
+// NewSubscriptionManager creates a SubscriptionManager backed by
+// the given resolver. The resolver MUST NOT be nil.
+func NewSubscriptionManager(resolver *HostsTxtResolver) *SubscriptionManager {
+	if resolver == nil {
+		panic("SubscriptionManager requires a non-nil HostsTxtResolver")
+	}
+
+	return &SubscriptionManager{
+		subscriptions: make(map[string]*Subscription),
+		resolver:      resolver,
+		client: &http.Client{
+			Timeout: DefaultFetchTimeout,
+		},
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Subscription management
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Add registers a subscription. If a subscription with the same URL already
+// exists, it is replaced (interval and name are updated).
+//
+// If interval is zero, the default (12h) is used.
+func (sm *SubscriptionManager) Add(url, name string, interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultSubscriptionInterval
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	sm.subscriptions[url] = &Subscription{
+		URL:      url,
+		Name:     name,
+		Interval: interval,
+	}
+
+	log.WithFields(logger.Fields{
+		"at":       "(SubscriptionManager) Add",
+		"url":      url,
+		"name":     name,
+		"interval": interval.String(),
+		"reason":   "subscription registered",
+	}).Info("subscription_added")
+}
+
+// Remove deletes a subscription by URL. No-op if the URL is not registered.
+func (sm *SubscriptionManager) Remove(url string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if _, ok := sm.subscriptions[url]; ok {
+		delete(sm.subscriptions, url)
+
+		log.WithFields(logger.Fields{
+			"at":     "(SubscriptionManager) Remove",
+			"url":    url,
+			"reason": "subscription removed",
+		}).Info("subscription_removed")
+	}
+}
+
+// List returns a snapshot of all currently registered subscriptions.
+// The returned slice is safe to read; modifications to the manager
+// do not affect it.
+func (sm *SubscriptionManager) List() []Subscription {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	result := make([]Subscription, 0, len(sm.subscriptions))
+	for _, s := range sm.subscriptions {
+		result = append(result, *s)
+	}
+	return result
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fetching
+// ──────────────────────────────────────────────────────────────────────────────
+
+// FetchAll fetches every registered subscription immediately.
+//
+// If one or more sources fail, the first error is returned but
+// FetchAll continues to fetch remaining sources. Individual fetch
+// failures are logged at warn level.
+func (sm *SubscriptionManager) FetchAll() error {
+	sm.mu.Lock()
+	subs := make([]*Subscription, 0, len(sm.subscriptions))
+	for _, s := range sm.subscriptions {
+		subs = append(subs, s)
+	}
+	sm.mu.Unlock()
+
+	var firstErr error
+
+	for _, s := range subs {
+		if err := sm.fetchOne(s); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
+// fetchOne fetches a single subscription and merges its entries.
+func (sm *SubscriptionManager) fetchOne(s *Subscription) error {
+	log.WithFields(logger.Fields{
+		"at":   "(SubscriptionManager) fetchOne",
+		"url":  s.URL,
+		"name": s.Name,
+	}).Debug("fetching_subscription")
+
+	ctx := sm.currentContext()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.URL, nil)
+	if err != nil {
+		return oops.Wrapf(err, "failed to create request for %s (%s)", s.Name, s.URL)
+	}
+
+	resp, err := sm.client.Do(req)
+	if err != nil {
+		log.WithFields(logger.Fields{
+			"at":     "(SubscriptionManager) fetchOne",
+			"url":    s.URL,
+			"name":   s.Name,
+			"error":  err.Error(),
+			"reason": "http_request_failed",
+		}).Warn("subscription_fetch_failed")
+		return oops.Wrapf(err, "failed to fetch %s (%s)", s.Name, s.URL)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.WithFields(logger.Fields{
+			"at":     "(SubscriptionManager) fetchOne",
+			"url":    s.URL,
+			"name":   s.Name,
+			"status": resp.StatusCode,
+			"reason": "non-2xx response",
+		}).Warn("subscription_fetch_non_2xx")
+		return oops.Errorf("non-2xx status %d from %s (%s)", resp.StatusCode, s.Name, s.URL)
+	}
+
+	// Limit response body to prevent memory exhaustion
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSubscriptionBody+1))
+	if err != nil {
+		log.WithFields(logger.Fields{
+			"at":     "(SubscriptionManager) fetchOne",
+			"url":    s.URL,
+			"name":   s.Name,
+			"error":  err.Error(),
+			"reason": "read_body_failed",
+		}).Warn("subscription_read_failed")
+		return oops.Wrapf(err, "failed to read body from %s (%s)", s.Name, s.URL)
+	}
+	if len(body) > maxSubscriptionBody {
+		log.WithFields(logger.Fields{
+			"at":     "(SubscriptionManager) fetchOne",
+			"url":    s.URL,
+			"name":   s.Name,
+			"limit":  maxSubscriptionBody,
+			"reason": "response_too_large",
+		}).Warn("subscription_response_too_large")
+		return oops.Errorf("response from %s (%s) exceeds %d bytes", s.Name, s.URL, maxSubscriptionBody)
+	}
+
+	// Merge entries into the resolver. addHostsData handles parsing,
+	// dedup, and logging — we just pass the raw bytes and source label.
+	source := fmt.Sprintf("subscription:%s (%s)", s.Name, s.URL)
+	if err := sm.resolver.addHostsData(body, source); err != nil {
+		log.WithFields(logger.Fields{
+			"at":     "(SubscriptionManager) fetchOne",
+			"url":    s.URL,
+			"name":   s.Name,
+			"error":  err.Error(),
+			"reason": "merge_failed",
+		}).Warn("subscription_merge_failed")
+		return oops.Wrapf(err, "failed to merge entries from %s (%s)", s.Name, s.URL)
+	}
+
+	log.WithFields(logger.Fields{
+		"at":   "(SubscriptionManager) fetchOne",
+		"url":  s.URL,
+		"name": s.Name,
+	}).Debug("subscription_fetch_complete")
+
+	return nil
+}
+
+// currentContext returns the manager context when running, or Background for
+// one-off fetches before Start is called.
+func (sm *SubscriptionManager) currentContext() context.Context {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.ctx != nil {
+		return sm.ctx
+	}
+	return context.Background()
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Lifecycle
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Start begins periodic fetching of all registered subscriptions.
+//
+// Each subscription runs in its own goroutine. On start, each subscription
+// is fetched immediately (not waiting for the first tick). A subscription
+// added after Start() is called will NOT be picked up by the periodic loop
+// until the manager is stopped and started again. Use FetchAll() for one-off
+// fetches.
+//
+// Start is idempotent — calling it on an already-started manager is a no-op.
+func (sm *SubscriptionManager) Start(ctx context.Context) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	sm.mu.Lock()
+	// Idempotency check: if we already have a context, we're running.
+	if sm.ctx != nil {
+		sm.mu.Unlock()
+		log.WithFields(logger.Fields{
+			"at": "(SubscriptionManager) Start",
+		}).Debug("subscription_manager_already_started")
+		return
+	}
+
+	sm.ctx, sm.cancel = context.WithCancel(ctx)
+
+	// Snapshot subscriptions so we don't hold the lock during goroutine launch.
+	subs := make([]*Subscription, 0, len(sm.subscriptions))
+	for _, s := range sm.subscriptions {
+		subs = append(subs, s)
+	}
+	sm.mu.Unlock()
+
+	for _, s := range subs {
+		sm.wg.Add(1)
+		go sm.runSubscription(s)
+	}
+
+	log.WithFields(logger.Fields{
+		"at":    "(SubscriptionManager) Start",
+		"count": len(subs),
+	}).Info("subscription_manager_started")
+}
+
+// Stop cancels periodic fetching and waits for in-flight fetches to finish.
+//
+// After Stop returns, the manager can be restarted with a new context
+// via Start().
+func (sm *SubscriptionManager) Stop() {
+	sm.mu.Lock()
+	if sm.cancel != nil {
+		sm.cancel()
+	}
+	sm.mu.Unlock()
+
+	sm.wg.Wait()
+
+	sm.mu.Lock()
+	sm.ctx = nil
+	sm.cancel = nil
+	sm.mu.Unlock()
+
+	log.WithFields(logger.Fields{
+		"at": "(SubscriptionManager) Stop",
+	}).Info("subscription_manager_stopped")
+}
+
+// runSubscription is the per-subscription goroutine. It fetches immediately
+// on start and then on each ticker interval. Exits when the manager's context
+// is cancelled.
+func (sm *SubscriptionManager) runSubscription(s *Subscription) {
+	defer sm.wg.Done()
+
+	// Fetch immediately on start
+	if err := sm.fetchOne(s); err != nil {
+		// Already logged in fetchOne
+		_ = err
+	}
+
+	ticker := time.NewTicker(s.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-sm.ctx.Done():
+			log.WithFields(logger.Fields{
+				"at":   "(SubscriptionManager) runSubscription",
+				"url":  s.URL,
+				"name": s.Name,
+			}).Debug("subscription_goroutine_stopping")
+			return
+		case <-ticker.C:
+			if err := sm.fetchOne(s); err != nil {
+				// Already logged in fetchOne
+				_ = err
+			}
+		}
+	}
+}

--- a/lib/naming/subscription_test.go
+++ b/lib/naming/subscription_test.go
@@ -1,0 +1,337 @@
+package naming
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+// testResolver creates a fresh resolver with no preloaded entries.
+func testResolver(t *testing.T) *HostsTxtResolver {
+	t.Helper()
+	r := &HostsTxtResolver{
+		hosts: make(map[string][]byte),
+	}
+	return r
+}
+
+// hostsLine returns a valid hosts.txt line. "AAAA" is a valid I2P base64
+// encoding per the existing parseHostsLine tests in resolver_test.go.
+func hostsLine(hostname string) string {
+	return hostname + "=AAAA\n"
+}
+
+// testHostsServer returns an httptest server serving a given hosts.txt body.
+func testHostsServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// =============================================================================
+// Add / Remove / List
+// =============================================================================
+
+func TestSubscriptionManager_AddRemoveList(t *testing.T) {
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+
+	assert.Len(t, sm.List(), 0, "new manager should have no subscriptions")
+
+	sm.Add("http://example.com/a.txt", "alpha", 0)
+	assert.Len(t, sm.List(), 1)
+
+	sm.Add("http://example.com/b.txt", "beta", 30*time.Minute)
+	assert.Len(t, sm.List(), 2)
+
+	// Duplicate URL replaces
+	sm.Add("http://example.com/a.txt", "alpha-v2", 1*time.Hour)
+	list := sm.List()
+	assert.Len(t, list, 2)
+	for _, s := range list {
+		if s.URL == "http://example.com/a.txt" {
+			assert.Equal(t, "alpha-v2", s.Name)
+			assert.Equal(t, 1*time.Hour, s.Interval)
+		}
+	}
+
+	sm.Remove("http://example.com/a.txt")
+	assert.Len(t, sm.List(), 1)
+
+	sm.Remove("http://example.com/nonexistent.txt") // no-op
+	assert.Len(t, sm.List(), 1)
+}
+
+func TestSubscriptionManager_DefaultInterval(t *testing.T) {
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+
+	sm.Add("http://example.com/hosts.txt", "test", 0)
+	list := sm.List()
+	require.Len(t, list, 1)
+	assert.Equal(t, defaultSubscriptionInterval, list[0].Interval)
+}
+
+func TestSubscriptionManager_ListReturnsCopy(t *testing.T) {
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+
+	sm.Add("http://example.com/a.txt", "a", time.Hour)
+
+	list1 := sm.List()
+	list1[0].Name = "modified"
+
+	list2 := sm.List()
+	assert.Equal(t, "a", list2[0].Name, "list should return a copy, not a reference")
+}
+
+// =============================================================================
+// FetchAll
+// =============================================================================
+
+func TestFetchAll_Success(t *testing.T) {
+	srv := testHostsServer(t, hostsLine("test.i2p"))
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+
+	sm.Add(srv.URL, "test-sub", time.Hour)
+
+	err := sm.FetchAll()
+	require.NoError(t, err)
+
+	dest, err := r.ResolveHostname("test.i2p")
+	require.NoError(t, err)
+	assert.NotEmpty(t, dest)
+}
+
+func TestFetchAll_MultipleSources(t *testing.T) {
+	srv1 := testHostsServer(t, hostsLine("alpha.i2p"))
+	srv2 := testHostsServer(t, hostsLine("beta.i2p"))
+
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+
+	sm.Add(srv1.URL, "alpha", time.Hour)
+	sm.Add(srv2.URL, "beta", time.Hour)
+
+	err := sm.FetchAll()
+	require.NoError(t, err)
+
+	_, err = r.ResolveHostname("alpha.i2p")
+	assert.NoError(t, err)
+	_, err = r.ResolveHostname("beta.i2p")
+	assert.NoError(t, err)
+}
+
+func TestFetchAll_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+	sm.Add(srv.URL, "broken", time.Hour)
+
+	err := sm.FetchAll()
+	assert.Error(t, err)
+}
+
+func TestFetchAll_MalformedLines(t *testing.T) {
+	body := "# this is a comment\n\n" +
+		hostsLine("valid.i2p") +
+		"line_without_equals\n" +
+		"also_bad=!!!invalid_base64!!!\n"
+
+	srv := testHostsServer(t, body)
+
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+	sm.Add(srv.URL, "mixed", time.Hour)
+
+	err := sm.FetchAll()
+	// Malformed lines are skipped, not fatal
+	require.NoError(t, err)
+
+	_, err = r.ResolveHostname("valid.i2p")
+	assert.NoError(t, err)
+
+	_, err = r.ResolveHostname("also_bad.i2p")
+	assert.Error(t, err)
+}
+
+func TestFetchAll_ResponseTooLarge(t *testing.T) {
+	srv := testHostsServer(t, strings.Repeat("a", maxSubscriptionBody+1))
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+
+	sm.Add(srv.URL, "too-large", time.Hour)
+
+	err := sm.FetchAll()
+	assert.Error(t, err)
+}
+
+// =============================================================================
+// Periodic refresh
+// =============================================================================
+
+func TestPeriodicRefresh(t *testing.T) {
+	srv := testHostsServer(t, hostsLine("refresh.i2p"))
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+
+	sm.Add(srv.URL, "refresh-test", 50*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sm.Start(ctx)
+
+	assert.Eventually(t, func() bool {
+		_, err := r.ResolveHostname("refresh.i2p")
+		return err == nil
+	}, 2*time.Second, 10*time.Millisecond, "first fetch should populate entry")
+
+	sm.Stop()
+}
+
+func TestStopCancelsFetch(t *testing.T) {
+	requestStarted := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+	sm.Add(srv.URL, "blocking", 50*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sm.Start(ctx)
+	<-requestStarted
+
+	// Stop should cancel the in-flight request and return promptly.
+	start := time.Now()
+	sm.Stop()
+	assert.Less(t, time.Since(start), 500*time.Millisecond)
+}
+
+func TestStartAfterStopRestarts(t *testing.T) {
+	var mu sync.Mutex
+	hostname := "first.i2p"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		body := hostsLine(hostname)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+	sm.Add(srv.URL, "restart-test", 50*time.Millisecond)
+
+	sm.Start(context.Background())
+	assert.Eventually(t, func() bool {
+		_, err := r.ResolveHostname("first.i2p")
+		return err == nil
+	}, 2*time.Second, 10*time.Millisecond)
+	sm.Stop()
+
+	mu.Lock()
+	hostname = "second.i2p"
+	mu.Unlock()
+
+	sm.Start(context.Background())
+	assert.Eventually(t, func() bool {
+		_, err := r.ResolveHostname("second.i2p")
+		return err == nil
+	}, 2*time.Second, 10*time.Millisecond)
+	sm.Stop()
+}
+
+// =============================================================================
+// Concurrent safety
+// =============================================================================
+
+func TestConcurrentAddAndFetch(t *testing.T) {
+	srv := testHostsServer(t, hostsLine("concurrent.i2p"))
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sm.Add(srv.URL, "concurrent", time.Hour)
+		}()
+	}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = sm.FetchAll()
+		}()
+	}
+
+	wg.Wait()
+
+	dest, err := r.ResolveHostname("concurrent.i2p")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, dest)
+}
+
+func TestNilResolverPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		NewSubscriptionManager(nil)
+	})
+}
+
+// =============================================================================
+// Idempotent Start
+// =============================================================================
+
+func TestStartIsIdempotent(t *testing.T) {
+	r := testResolver(t)
+	sm := NewSubscriptionManager(r)
+
+	srv := testHostsServer(t, hostsLine("idem.i2p"))
+	sm.Add(srv.URL, "idem-test", 50*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sm.Start(ctx)
+	sm.Start(ctx) // second call is no-op
+
+	assert.Eventually(t, func() bool {
+		_, err := r.ResolveHostname("idem.i2p")
+		return err == nil
+	}, 2*time.Second, 10*time.Millisecond)
+
+	sm.Stop()
+}


### PR DESCRIPTION
## What

Add `SubscriptionManager` in `lib/naming/` that periodically fetches remote hosts.txt files via HTTP and merges entries into a `HostsTxtResolver`.

## Why

The naming package currently only loads the embedded `hosts.txt`. I2P routers commonly subscribe to additional remote hosts.txt sources for address resolution. This addresses the naming gap identified in the project audit (currently ~60% complete).

## Changes

- **`subscription.go`** (~250 lines) — `SubscriptionManager` with Add/Remove/List, `FetchAll` (immediate), `Start`/`Stop` (periodic goroutine per subscription)
- **`subscription_test.go`** (~260 lines) — 10 tests: add/remove/list, fetch success/multiple/error/malformed, periodic refresh, stop cancels, concurrency, nil panic, idempotent start
- Zero changes to existing files (uses unexported `addHostsData` directly)

## Design Decisions

- Default interval: 12h (matches i2pd behavior)
- Max response body: 1 MiB
- HTTP errors logged at warn, not fatal — continues fetching other sources
- Malformed lines skipped with warn log, valid lines still merged
- Idempotent `Start()`, concurrent-safe `Add()` + `FetchAll()`

## Planned Follow-ups (seeking feedback)

Two items I plan to add in subsequent PRs:

1. **ETag / If-Modified-Since caching** — avoid re-downloading unchanged hosts.txt. Store last `ETag` and `Last-Modified` per subscription; send `If-None-Match` / `If-Modified-Since` on subsequent fetches; skip merge on 304.

2. **Subscription persistence to disk** — persist the subscription list (URL, name, interval) so that `Start()` can restore subscriptions from a previous run without re-registration.

Would these be welcome? Happy to adjust scope based on feedback.

## Style

Follows project conventions: `oops.Errorf` / `oops.Wrapf`, `log.WithFields` with `"at"` + `"reason"`, em-dash section separators, `require`/`assert` in tests.

Closes: (none — new feature)