### PR TITLE
Update: `security_unit_test.go` need to use EvalSymLinks to clean path properly on macOS

### DIFF
--- a/lib/config/security_unit_test.go
+++ b/lib/config/security_unit_test.go
@@ -18,6 +18,10 @@ import (
 func TestSanitizePath_ValidPaths(t *testing.T) {
 	tempDir := t.TempDir()
 
+	if cleanTemp, err := filepath.EvalSymlinks(tempDir); err == nil {
+		tempDir = cleanTemp
+	}
+
 	testCases := []struct {
 		name     string
 		basePath string


### PR DESCRIPTION
temp file on macOS.

## Summary

- Updated testing behavior to accommodate to macOS behavior  
- Might need to live in `security.go` function - `SanitizePath` pending review

## Validation

- [x] `go test ./...` --passes