### PR TITLE
Fix nil db store msg

### DIFF
--- a/lib/i2np/processor_handlers.go
+++ b/lib/i2np/processor_handlers.go
@@ -228,6 +228,7 @@ func coerceDatabaseStoreMessage(msg Message) (*DatabaseStore, error) {
 		return nil, oops.Wrapf(err, "failed to parse DatabaseStore payload")
 	}
 
+	dbStore.BaseI2NPMessage = BaseMessageFromMessage(msg, payload)
 	return dbStore, nil
 }
 
@@ -252,6 +253,7 @@ func coerceDatabaseSearchReplyMessage(msg Message) (*DatabaseSearchReply, error)
 	if err != nil {
 		return nil, oops.Wrapf(err, "failed to parse DatabaseSearchReply payload")
 	}
+	searchReply.BaseI2NPMessage = BaseMessageFromMessage(msg, payload)
 
 	return searchReply, nil
 }

--- a/lib/i2np/processor_unit_test.go
+++ b/lib/i2np/processor_unit_test.go
@@ -372,6 +372,16 @@ func TestProcessDatabaseStoreMessage_FromBaseMessageDataCarrier(t *testing.T) {
 
 	base := NewBaseI2NPMessage(I2NPMessageTypeDatabaseStore)
 	base.SetData(body)
+	base.SetMessageID(0x10203040)
+	base.SetExpiration(time.Unix(1_770_000_000, 0).UTC())
+
+	parsed, err := coerceDatabaseStoreMessage(base)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.BaseI2NPMessage)
+	assert.Equal(t, base.Type(), parsed.Type())
+	assert.Equal(t, base.MessageID(), parsed.MessageID())
+	assert.Equal(t, base.Expiration(), parsed.Expiration())
+	assert.Equal(t, body, parsed.GetData())
 
 	err = processor.processDatabaseStoreMessage(base)
 	require.NoError(t, err)
@@ -432,6 +442,16 @@ func TestProcessDatabaseSearchReplyMessage_FromBaseMessageDataCarrier(t *testing
 
 	base := NewBaseI2NPMessage(I2NPMessageTypeDatabaseSearchReply)
 	base.SetData(body)
+	base.SetMessageID(0x50607080)
+	base.SetExpiration(time.Unix(1_770_000_060, 0).UTC())
+
+	parsed, err := coerceDatabaseSearchReplyMessage(base)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.BaseI2NPMessage)
+	assert.Equal(t, base.Type(), parsed.Type())
+	assert.Equal(t, base.MessageID(), parsed.MessageID())
+	assert.Equal(t, base.Expiration(), parsed.Expiration())
+	assert.Equal(t, body, parsed.GetData())
 
 	err = processor.processDatabaseSearchReplyMessage(base)
 	require.NoError(t, err)

--- a/lib/i2np/utils.go
+++ b/lib/i2np/utils.go
@@ -539,3 +539,13 @@ func ValidateRecordCount(countField, recordCount int, tunnelTypeName string) err
 
 	return nil
 }
+
+// BaseMessageFromMessage creates a base message using metadata from msg and payload.
+func BaseMessageFromMessage(msg Message, payload []byte) *BaseI2NPMessage {
+	return &BaseI2NPMessage{
+		type_:      msg.Type(),
+		messageID:  msg.MessageID(),
+		expiration: msg.Expiration(),
+		data:       payload,
+	}
+}

--- a/lib/router/router_message_dispatch.go
+++ b/lib/router/router_message_dispatch.go
@@ -406,6 +406,7 @@ func (r *Router) parseDatabaseStoreMessage(msg i2np.Message) (*i2np.DatabaseStor
 		"key":        dbStore.GetStoreKey().String(),
 	}).Info("Parsed DatabaseStore message from peer")
 
+	dbStore.BaseI2NPMessage = i2np.BaseMessageFromMessage(msg, dataCarrier.GetData())
 	return dbStore, nil
 }
 
@@ -436,11 +437,7 @@ func (r *Router) parseDatabaseSearchReplyMessage(msg i2np.Message) (*i2np.Databa
 		return nil, oops.Wrapf(err, "failed to parse DatabaseSearchReply")
 	}
 
-	base := i2np.NewBaseI2NPMessage(i2np.I2NPMessageTypeDatabaseSearchReply)
-	base.SetMessageID(msg.MessageID())
-	base.SetExpiration(msg.Expiration())
-	base.SetData(payload)
-	searchReply.BaseI2NPMessage = base
+	searchReply.BaseI2NPMessage = i2np.BaseMessageFromMessage(msg, payload)
 
 	return searchReply, nil
 }


### PR DESCRIPTION
## Summary

- Creating a BaseI2NPMessage from a Message.

What was happening:

DatabaseStore messages kept processing as nil, the reason being was the internal i2npBaseMessage was never being set, causing a panic in `processor.go` when processing a message type. BaseMessageFromMessage helps resolve this by copying over message fields and setting it within our DbStore Message. This same pattern was being observed within `searchReply`. 

Let me know if this was intended behavior or not, if so then close this PR.

## Validation

- [X] `go test ./...`
- [X] `go vet ./...`