### PR TITLE
Chore/lefthook ci setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ err
 *.disabled
 *.bak
 *.backup*
+*.yaml
+*.log
+*.dat
+*.env
+.zed
+.vscode
+.DS_store

--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,4 @@ setup:
 	go install github.com/github-release/github-release@latest
 	go install github.com/ofabry/go-callvis@latest
 	go install github.com/evilmartians/lefthook@latest
+	lefthook install

--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,4 @@ setup:
 	go install github.com/github-release/github-release@latest
 	go install github.com/ofabry/go-callvis@latest
 	go install mvdan.cc/gofumpt@latest
-	lefthook install
+	go install github.com/evilmartians/lefthook@latest

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ godoc:
 setup:
 	go install github.com/aquasecurity/trivy/cmd/trivy@latest
 	go install github.com/leaanthony/comply@latest
-	go install mvdan.cc/gofumpt@latest"
+	go install mvdan.cc/gofumpt@latest
 	go install github.com/robertkrimen/godocdown@latest
 	go install github.com/github-release/github-release@latest
 	go install github.com/ofabry/go-callvis@latest

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,13 @@ godoc:
 	./callgraph.sh
 	find . -name 'README.md' -exec git add -v {} \;
 	git commit -am "GODOC UPDATE CHECKIN"
+
+setup:
+	go install github.com/aquasecurity/trivy/cmd/trivy@latest
+	go install github.com/leaanthony/comply@latest
+	go install mvdan.cc/gofumpt@latest"
+	go install github.com/robertkrimen/godocdown@latest
+	go install github.com/github-release/github-release@latest
+	go install github.com/ofabry/go-callvis@latest
+	go install mvdan.cc/gofumpt@latest
+	lefthook install

--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,10 @@ godoc:
 	git commit -am "GODOC UPDATE CHECKIN"
 
 setup:
-	go install github.com/aquasecurity/trivy/cmd/trivy@latest
+	GOEXPERIMENT=jsonv2 go install github.com/aquasecurity/trivy/cmd/trivy@latest
 	go install github.com/leaanthony/comply@latest
 	go install mvdan.cc/gofumpt@latest
-	go install github.com/robertkrimen/godocdown@latest
+	go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest # update to a stable version of gomarkdoc
 	go install github.com/github-release/github-release@latest
 	go install github.com/ofabry/go-callvis@latest
-	go install mvdan.cc/gofumpt@latest
 	go install github.com/evilmartians/lefthook@latest

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# lefthook.yml
+pre-commit:
+  commands:
+    gofumpt:
+      glob: "*.go"
+      run: gofumpt -w -extra {staged_files}
+
+pre-push:
+  commands:
+    vet:
+      run: go vet ./...
+    test:
+      run: go test ./...

--- a/lib/i2np/processor.go
+++ b/lib/i2np/processor.go
@@ -1,6 +1,7 @@
 package i2np
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -470,6 +471,7 @@ func (p *MessageProcessor) processMessageWithDepth(msg Message, depth int) error
 
 	messageType, err := safeProcessorMessageType(msg)
 	if err != nil {
+		fmt.Println("---------- WITH DEPTH IN HERE ERROR --------------")
 		return err
 	}
 

--- a/lib/i2np/processor.go
+++ b/lib/i2np/processor.go
@@ -1,7 +1,6 @@
 package i2np
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -471,7 +470,6 @@ func (p *MessageProcessor) processMessageWithDepth(msg Message, depth int) error
 
 	messageType, err := safeProcessorMessageType(msg)
 	if err != nil {
-		fmt.Println("---------- WITH DEPTH IN HERE ERROR --------------")
 		return err
 	}
 

--- a/lib/i2np/processor.go
+++ b/lib/i2np/processor.go
@@ -1,6 +1,7 @@
 package i2np
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -472,6 +473,8 @@ func (p *MessageProcessor) processMessageWithDepth(msg Message, depth int) error
 	if err != nil {
 		return err
 	}
+
+	func() { fmt.Println("test") }()
 
 	messageID, err := safeProcessorMessageID(msg)
 	if err != nil {

--- a/lib/i2np/processor.go
+++ b/lib/i2np/processor.go
@@ -1,7 +1,6 @@
 package i2np
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -473,8 +472,6 @@ func (p *MessageProcessor) processMessageWithDepth(msg Message, depth int) error
 	if err != nil {
 		return err
 	}
-
-	func() { fmt.Println("test") }()
 
 	messageID, err := safeProcessorMessageID(msg)
 	if err != nil {


### PR DESCRIPTION
## Summary

This is my own "suggestion" for the CI setup and makefile. What I did was:

- update the .gitignore to stop persisting files from being committed. 

- `setup` make command. Downloads the latest deps needed & ensures stable versions

- `lefthook.yml` essentially this is a pre-commit & pre-push checker. This can save a CI cycle and ensure every push passes all tests & lints. This can always be bypassed by --no-verify, but it helps ensure less mistakes make it upstream. This can also be configured to not run test on every push, this can be a bit excessive. Will remove if this is the case


This is all optional & quality of life suggestions for developers. 